### PR TITLE
feat: add canonical CI validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.10.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Test Invariants
+        run: pnpm test:invariants
+
+      - name: Build
+        run: pnpm build
+
+      - name: Scripts Lint
+        run: pnpm scripts:lint

--- a/README.md
+++ b/README.md
@@ -90,9 +90,25 @@ pnpm lint
 pnpm test
 pnpm test:invariants
 pnpm build
+pnpm scripts:lint
 pnpm spec:generate
 pnpm skills:check:strict
 ```
+
+## CI Contract
+
+The canonical repository CI contract lives at
+`.github/workflows/ci.yml`.
+
+For every PR to `main`, CI pins Node (`22.10.0`), installs with
+`pnpm install --frozen-lockfile`, and runs:
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm test:invariants`
+- `pnpm build`
+- `pnpm scripts:lint`
 
 ## Ready-for-Dev Loop Runner
 

--- a/packages/api/src/server/router/__tests__/helpers.ts
+++ b/packages/api/src/server/router/__tests__/helpers.ts
@@ -1,8 +1,8 @@
 import { ORPCError } from '@orpc/client';
 import { ManagedRuntime, type Layer } from 'effect';
-import type { User } from '@repo/auth/policy';
 import type { AuthenticatedORPCContext, ORPCContext } from '../../orpc';
 import type { ServerRuntime } from '../../runtime';
+import type { User } from '@repo/auth/policy';
 
 interface TestSession {
   session: {

--- a/packages/db/src/__tests__/job-schema.test.ts
+++ b/packages/db/src/__tests__/job-schema.test.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema } from 'effect';
 import { describe, expect, it } from 'vitest';
+import type { JobId } from '../schemas/brands';
 import {
   JobStatus,
   JobStatusSchema,
@@ -8,7 +9,6 @@ import {
   serializeJob,
   serializeJobEffect,
 } from '../schemas/jobs';
-import type { JobId } from '../schemas/brands';
 
 describe('jobs schema', () => {
   it('exposes expected JobStatus constants', () => {


### PR DESCRIPTION
## Summary
- add a canonical GitHub Actions workflow at `.github/workflows/ci.yml` for PRs/pushes on `main`
- enforce deterministic installs in CI via pinned Node `22.10.0`, pnpm `10.23.0`, and `pnpm install --frozen-lockfile`
- run the repository validation contract in CI (`typecheck`, `lint`, `test`, `test:invariants`, `build`, `scripts:lint`)
- document the CI contract location and enforced gates in `README.md`
- apply no-behavior-change import-order cleanups in two test files so baseline `pnpm lint` passes

## Aggregated Issues
- Fixes #1 (primary, fully resolved)

## Workflow Routing
- #1 -> `Self-Improvement`
  - Skills: `self-improvement` (primary), `intake-triage` (companion)
