### PR TITLE
feat: restore API run router boundaries and invariants

### DIFF
--- a/docs/testing/invariants.md
+++ b/docs/testing/invariants.md
@@ -24,6 +24,19 @@ Required for all agent-authored backend changes.
 | Chat routes avoid direct `runtime.runPromise` | Bypassing shared handler pipeline |
 | Chat handlers define `api.chat.*` spans | Missing or inconsistent tracing |
 
+### API Router Handler Invariants
+<!-- enforced-by: invariant-test -->
+
+**File:** `packages/api/src/server/__tests__/router-handler.invariants.test.ts`
+
+| Rule | What It Prevents |
+|---|---|
+| Every handler router file must be covered by explicit invariant rules | Missing coverage when routers are added/renamed |
+| No direct `runtime.runPromise` calls in handler routers | Bypassing shared protocol pipeline |
+| No `@repo/db/schema` imports in handler routers unless allowlisted | API-to-DB boundary drift |
+| Effect-backed handlers must use standardized helper pipeline | Inconsistent protocol mapping and telemetry behavior |
+| Handler spans must use `api.*` naming, or explicit SSE exemption rationale | Missing/implicit observability contracts |
+
 ### Error Assertion Invariants
 <!-- enforced-by: invariant-test -->
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "turbo run start",
     "test": "vitest run",
     "test:scripts": "vitest run --config agent-engine/scripts/vitest.config.ts",
-    "test:invariants": "vitest run packages/api/src/server/__tests__/effect-handler.invariants.test.ts packages/api/src/server/__tests__/error-assertions.invariants.test.ts packages/api/src/server/__tests__/chat-handler.invariants.test.ts packages/testing/src/__tests__/docs-invariants.test.ts",
+    "test:invariants": "vitest run packages/api/src/server/__tests__/effect-handler.invariants.test.ts packages/api/src/server/__tests__/error-assertions.invariants.test.ts packages/api/src/server/__tests__/chat-handler.invariants.test.ts packages/api/src/server/__tests__/router-handler.invariants.test.ts packages/testing/src/__tests__/docs-invariants.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:coverage:api": "pnpm --filter @repo/api test:coverage",

--- a/packages/api/src/server/__tests__/router-handler.invariants.test.ts
+++ b/packages/api/src/server/__tests__/router-handler.invariants.test.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, '..', '..', '..', '..', '..');
+const routerDir = path.join(repoRoot, 'packages/api/src/server/router');
+
+type HelperRequirement =
+  | 'handleEffectWithProtocol'
+  | 'handleEffectStreamWithProtocol'
+  | null;
+
+interface RouterRule {
+  readonly helper: HelperRequirement;
+  readonly minSpanCount: number | null;
+  readonly spanPrefix: string | null;
+  readonly rationale?: string;
+}
+
+const ROUTER_RULES: Record<string, RouterRule> = {
+  'chat.ts': {
+    helper: 'handleEffectStreamWithProtocol',
+    minSpanCount: 1,
+    spanPrefix: 'api.chat.',
+  },
+  'events.ts': {
+    helper: null,
+    minSpanCount: null,
+    spanPrefix: null,
+    rationale:
+      'SSE subscribe is async-generator based, so protocol helper/span requirements are explicitly exempted.',
+  },
+  'runs.ts': {
+    helper: 'handleEffectWithProtocol',
+    minSpanCount: 2,
+    spanPrefix: 'api.runs.',
+  },
+};
+
+const DB_SCHEMA_IMPORT_ALLOWLIST = new Set<string>([]);
+
+const readRouterSource = (filename: string) =>
+  fs.readFileSync(path.join(routerDir, filename), 'utf-8');
+
+const listRouterHandlerFiles = () =>
+  fs
+    .readdirSync(routerDir)
+    .filter((file) => file.endsWith('.ts'))
+    .filter((file) => file !== 'index.ts')
+    .sort();
+
+describe('router handler invariants', () => {
+  it('covers every handler router with explicit invariant rules', () => {
+    const routerFiles = listRouterHandlerFiles();
+    const ruleFiles = Object.keys(ROUTER_RULES).sort();
+
+    expect(ruleFiles).toEqual(routerFiles);
+  });
+
+  it('forbids direct runtime.runPromise usage in routers', () => {
+    const forbidden = /context\.runtime\.runPromise/;
+
+    for (const file of listRouterHandlerFiles()) {
+      const source = readRouterSource(file);
+
+      if (forbidden.test(source)) {
+        throw new Error(`Router ${file} must not call context.runtime.runPromise`);
+      }
+    }
+  });
+
+  it('forbids @repo/db/schema imports in routers unless allowlisted', () => {
+    const forbiddenImport = /from ['"]@repo\/db\/schema['"]/;
+
+    for (const file of listRouterHandlerFiles()) {
+      if (DB_SCHEMA_IMPORT_ALLOWLIST.has(file)) {
+        continue;
+      }
+
+      const source = readRouterSource(file);
+      if (forbiddenImport.test(source)) {
+        throw new Error(`Router ${file} must not import @repo/db/schema directly`);
+      }
+    }
+  });
+
+  it('requires standardized helper pipelines for Effect-backed handlers', () => {
+    for (const file of listRouterHandlerFiles()) {
+      const source = readRouterSource(file);
+      const rule = ROUTER_RULES[file];
+
+      if (!rule) {
+        throw new Error(`Missing invariant rule for router ${file}`);
+      }
+
+      if (rule.helper === null) {
+        if (!rule.rationale) {
+          throw new Error(`Router ${file} is exempt but missing rationale`);
+        }
+        expect(source).toContain('async function*');
+        continue;
+      }
+
+      expect(source).toContain(rule.helper);
+    }
+  });
+
+  it('requires API spans or explicit exemptions with rationale', () => {
+    for (const file of listRouterHandlerFiles()) {
+      const source = readRouterSource(file);
+      const rule = ROUTER_RULES[file];
+
+      if (!rule) {
+        throw new Error(`Missing invariant rule for router ${file}`);
+      }
+
+      if (rule.minSpanCount === null || rule.spanPrefix === null) {
+        if (!rule.rationale) {
+          throw new Error(`Router ${file} span exemption missing rationale`);
+        }
+        expect(source).toContain('protectedProcedure.events.subscribe.handler');
+        continue;
+      }
+
+      const escapedPrefix = rule.spanPrefix.replaceAll('.', '\\.');
+      const spanPattern = new RegExp(`span:\\s*'${escapedPrefix}[^']+'`, 'g');
+      const matches = source.match(spanPattern) ?? [];
+
+      expect(matches.length).toBeGreaterThanOrEqual(rule.minSpanCount);
+    }
+  });
+});

--- a/packages/api/src/server/router/events.ts
+++ b/packages/api/src/server/router/events.ts
@@ -2,6 +2,8 @@ import { protectedProcedure } from '../orpc';
 import { ssePublisher } from '../publisher';
 
 const eventsRouter = {
+  // Intentional exception: SSE is an async generator contract and cannot use
+  // Effect protocol helpers without changing stream semantics.
   subscribe: protectedProcedure.events.subscribe.handler(async function* ({
     context,
     signal,

--- a/packages/api/src/server/router/runs.ts
+++ b/packages/api/src/server/router/runs.ts
@@ -1,47 +1,6 @@
-import { JobType } from '@repo/db/schema';
-import { Queue, type Job } from '@repo/queue';
-import { Effect, Schema } from 'effect';
-import {
-  RunResultSchema,
-  type RunOutput,
-  type RunResult,
-} from '../../contracts/runs';
 import { handleEffectWithProtocol } from '../effect-handler';
 import { protectedProcedure } from '../orpc';
-import { ssePublisher } from '../publisher';
-
-type RunPayload = {
-  prompt?: unknown;
-  threadId?: unknown;
-};
-
-const decodeRunResult = Schema.decodeUnknownSync(RunResultSchema);
-
-const toOptionalString = (value: unknown): string | null =>
-  typeof value === 'string' && value.trim().length > 0 ? value : null;
-
-const toRunResult = (value: unknown): RunResult | null => {
-  if (value == null) return null;
-
-  try {
-    return decodeRunResult(value);
-  } catch {
-    return null;
-  }
-};
-
-const toRunOutput = (job: Job<RunPayload>): RunOutput => ({
-  id: job.id,
-  status: job.status,
-  prompt: toOptionalString(job.payload?.prompt) ?? '',
-  threadId: toOptionalString(job.payload?.threadId),
-  result: toRunResult(job.result),
-  error: job.error,
-  createdAt: job.createdAt.toISOString(),
-  updatedAt: job.updatedAt.toISOString(),
-  startedAt: job.startedAt?.toISOString() ?? null,
-  completedAt: job.completedAt?.toISOString() ?? null,
-});
+import { createRunUseCase, listRunsUseCase } from '../use-cases/runs';
 
 const runsRouter = {
   create: protectedProcedure.runs.create.handler(
@@ -49,33 +8,7 @@ const runsRouter = {
       handleEffectWithProtocol(
         context.runtime,
         context.user,
-        Effect.gen(function* () {
-          const queue = yield* Queue;
-
-          const created = yield* queue.enqueue(
-            JobType.PROCESS_AI_RUN,
-            {
-              prompt: input.prompt,
-              threadId: input.threadId ?? null,
-              userId: context.user.id,
-            },
-            context.user.id,
-          );
-
-          const run = toRunOutput(created as Job<RunPayload>);
-
-          yield* Effect.sync(() =>
-            ssePublisher.publish(context.user.id, {
-              type: 'run_queued',
-              runId: run.id,
-              prompt: run.prompt,
-              threadId: run.threadId,
-              timestamp: new Date().toISOString(),
-            }),
-          );
-
-          return run;
-        }),
+        createRunUseCase({ user: context.user, input }),
         errors,
         {
           requestId: context.requestId,
@@ -88,18 +21,7 @@ const runsRouter = {
     handleEffectWithProtocol(
       context.runtime,
       context.user,
-      Effect.gen(function* () {
-        const queue = yield* Queue;
-        const jobs = yield* queue.getJobsByUser(
-          context.user.id,
-          JobType.PROCESS_AI_RUN,
-        );
-        const runs = jobs
-          .map((job) => toRunOutput(job as Job<RunPayload>))
-          .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-
-        return input.limit ? runs.slice(0, input.limit) : runs;
-      }),
+      listRunsUseCase({ user: context.user, input }),
       errors,
       {
         requestId: context.requestId,

--- a/packages/api/src/server/use-cases/__tests__/runs.test.ts
+++ b/packages/api/src/server/use-cases/__tests__/runs.test.ts
@@ -1,0 +1,176 @@
+import {
+  Queue,
+  QueueError,
+  QueueJobType,
+  type Job,
+  type QueueService,
+} from '@repo/queue';
+import { Effect, Layer } from 'effect';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { User } from '@repo/auth/policy';
+import { ssePublisher } from '../../publisher';
+import { createRunUseCase, listRunsUseCase } from '../runs';
+
+const TEST_USER: User = {
+  id: 'user_test',
+  email: 'test@example.com',
+  name: 'Test User',
+  role: 'user',
+};
+
+const createMockQueueService = (
+  overrides: Partial<QueueService> = {},
+): QueueService => ({
+  enqueue: () => Effect.die('enqueue not mocked'),
+  getJob: () => Effect.die('getJob not mocked'),
+  getJobsByUser: () => Effect.die('getJobsByUser not mocked'),
+  updateJobStatus: () => Effect.die('updateJobStatus not mocked'),
+  processNextJob: () => Effect.die('processNextJob not mocked'),
+  processJobById: () => Effect.die('processJobById not mocked'),
+  claimNextJob: () => Effect.die('claimNextJob not mocked'),
+  deleteJob: () => Effect.die('deleteJob not mocked'),
+  failStaleJobs: () => Effect.die('failStaleJobs not mocked'),
+  ...overrides,
+});
+
+const createJob = (overrides: Partial<Job> = {}): Job => ({
+  id: 'job_test' as Job['id'],
+  type: QueueJobType.PROCESS_AI_RUN,
+  status: 'pending',
+  payload: {},
+  result: null,
+  error: null,
+  createdBy: TEST_USER.id,
+  createdAt: new Date('2026-02-23T00:00:00.000Z'),
+  updatedAt: new Date('2026-02-23T00:00:00.000Z'),
+  startedAt: null,
+  completedAt: null,
+  ...overrides,
+});
+
+const withQueue = (queue: QueueService) => Effect.provide(Layer.succeed(Queue, queue));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('runs use-cases', () => {
+  it('scopes create run to the authenticated user and publishes queue event', async () => {
+    let enqueueType: string | undefined;
+    let enqueuePayload: unknown;
+    let enqueueUserId: string | undefined;
+
+    const queue = createMockQueueService({
+      enqueue: (type, payload, userId) => {
+        enqueueType = type;
+        enqueuePayload = payload;
+        enqueueUserId = userId;
+        return Effect.succeed(createJob({ payload }));
+      },
+    });
+
+    const publishSpy = vi
+      .spyOn(ssePublisher, 'publish')
+      .mockImplementation(() => undefined);
+
+    const result = await Effect.runPromise(
+      createRunUseCase({
+        user: TEST_USER,
+        input: {
+          prompt: 'Plan quarterly roadmap',
+          threadId: 'thread_123',
+        },
+      }).pipe(withQueue(queue)),
+    );
+
+    expect(enqueueType).toBe(QueueJobType.PROCESS_AI_RUN);
+    expect(enqueueUserId).toBe(TEST_USER.id);
+    expect(enqueuePayload).toEqual({
+      prompt: 'Plan quarterly roadmap',
+      threadId: 'thread_123',
+      userId: TEST_USER.id,
+    });
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(result.prompt).toBe('Plan quarterly roadmap');
+    expect(result.threadId).toBe('thread_123');
+  });
+
+  it('preserves typed queue errors for create run failures', async () => {
+    const queueError = new QueueError({ message: 'queue unavailable' });
+    const queue = createMockQueueService({
+      enqueue: () => Effect.fail(queueError),
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        createRunUseCase({
+          user: TEST_USER,
+          input: {
+            prompt: 'Plan quarterly roadmap',
+          },
+        }).pipe(withQueue(queue)),
+      ),
+    );
+
+    expect(error._tag).toBe('QueueError');
+    expect(error.message).toBe('queue unavailable');
+  });
+
+  it('scopes list runs to user ownership and applies descending order + limit', async () => {
+    let listUserId: string | undefined;
+    let listType: string | undefined;
+
+    const queue = createMockQueueService({
+      getJobsByUser: (userId, type) => {
+        listUserId = userId;
+        listType = type;
+
+        return Effect.succeed([
+          createJob({
+            id: 'job_old' as Job['id'],
+            payload: { prompt: 'older' },
+            createdAt: new Date('2026-02-20T00:00:00.000Z'),
+            updatedAt: new Date('2026-02-20T00:00:00.000Z'),
+          }),
+          createJob({
+            id: 'job_new' as Job['id'],
+            payload: { prompt: 'newer' },
+            createdAt: new Date('2026-02-22T00:00:00.000Z'),
+            updatedAt: new Date('2026-02-22T00:00:00.000Z'),
+          }),
+        ]);
+      },
+    });
+
+    const runs = await Effect.runPromise(
+      listRunsUseCase({
+        user: TEST_USER,
+        input: { limit: 1 },
+      }).pipe(withQueue(queue)),
+    );
+
+    expect(listUserId).toBe(TEST_USER.id);
+    expect(listType).toBe(QueueJobType.PROCESS_AI_RUN);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe('job_new');
+  });
+
+  it('preserves typed queue errors for list run failures', async () => {
+    const queueError = new QueueError({ message: 'query failed' });
+    const queue = createMockQueueService({
+      getJobsByUser: () => Effect.fail(queueError),
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        listRunsUseCase({
+          user: TEST_USER,
+          input: {},
+        }).pipe(withQueue(queue)),
+      ),
+    );
+
+    expect(error._tag).toBe('QueueError');
+    expect(error.message).toBe('query failed');
+  });
+});

--- a/packages/api/src/server/use-cases/runs.ts
+++ b/packages/api/src/server/use-cases/runs.ts
@@ -1,0 +1,97 @@
+import { Queue, QueueJobType, type Job } from '@repo/queue';
+import { Effect, Schema } from 'effect';
+import type { User } from '@repo/auth/policy';
+import {
+  RunResultSchema,
+  type CreateRunInput,
+  type RunOutput,
+  type RunResult,
+} from '../../contracts/runs';
+import { ssePublisher } from '../publisher';
+
+type RunPayload = {
+  prompt?: unknown;
+  threadId?: unknown;
+};
+
+type ListRunsInput = {
+  readonly limit?: number;
+};
+
+export interface CreateRunUseCaseInput {
+  readonly user: User;
+  readonly input: CreateRunInput;
+}
+
+export interface ListRunsUseCaseInput {
+  readonly user: User;
+  readonly input: ListRunsInput;
+}
+
+const decodeRunResult = Schema.decodeUnknownSync(RunResultSchema);
+
+const toOptionalString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim().length > 0 ? value : null;
+
+const toRunResult = (value: unknown): RunResult | null => {
+  if (value == null) return null;
+
+  try {
+    return decodeRunResult(value);
+  } catch {
+    return null;
+  }
+};
+
+const toRunOutput = (job: Job<RunPayload>): RunOutput => ({
+  id: job.id,
+  status: job.status,
+  prompt: toOptionalString(job.payload?.prompt) ?? '',
+  threadId: toOptionalString(job.payload?.threadId),
+  result: toRunResult(job.result),
+  error: job.error,
+  createdAt: job.createdAt.toISOString(),
+  updatedAt: job.updatedAt.toISOString(),
+  startedAt: job.startedAt?.toISOString() ?? null,
+  completedAt: job.completedAt?.toISOString() ?? null,
+});
+
+export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
+  Effect.gen(function* () {
+    const queue = yield* Queue;
+
+    const created = yield* queue.enqueue(
+      QueueJobType.PROCESS_AI_RUN,
+      {
+        prompt: input.prompt,
+        threadId: input.threadId ?? null,
+        userId: user.id,
+      },
+      user.id,
+    );
+
+    const run = toRunOutput(created as Job<RunPayload>);
+
+    yield* Effect.sync(() =>
+      ssePublisher.publish(user.id, {
+        type: 'run_queued',
+        runId: run.id,
+        prompt: run.prompt,
+        threadId: run.threadId,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    return run;
+  });
+
+export const listRunsUseCase = ({ user, input }: ListRunsUseCaseInput) =>
+  Effect.gen(function* () {
+    const queue = yield* Queue;
+    const jobs = yield* queue.getJobsByUser(user.id, QueueJobType.PROCESS_AI_RUN);
+    const runs = jobs
+      .map((job) => toRunOutput(job as Job<RunPayload>))
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+
+    return input.limit ? runs.slice(0, input.limit) : runs;
+  });

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -1,12 +1,15 @@
 import type {
   JobId,
   JobStatus as DbJobStatus,
-  JobType as DbJobType,
 } from '@repo/db/schema';
 
 export type JobStatus = DbJobStatus;
 
-export type JobType = DbJobType[keyof DbJobType];
+export const QueueJobType = {
+  PROCESS_AI_RUN: 'process-ai-run',
+} as const;
+
+export type JobType = (typeof QueueJobType)[keyof typeof QueueJobType];
 
 export interface Job<TPayload = unknown, TResult = unknown> {
   readonly id: JobId;


### PR DESCRIPTION
## Summary
- extract run orchestration from API handlers into explicit use-cases (`createRunUseCase`, `listRunsUseCase`)
- keep `runs` handlers transport-focused and preserve oRPC contract output shapes
- add queue-domain `QueueJobType` constant so API routing no longer depends on `@repo/db/schema`
- add router-wide invariant coverage for helper usage, span declarations, runtime bypass prevention, and router import boundaries
- document and encode the SSE generator exemption rationale for `events.subscribe`

## Aggregated Issues
- Fixes #6 - Extract run/event orchestration into explicit use-cases to restore handler boundaries
- Fixes #7 - Expand API handler invariants to cover all routers and span discipline
- Fixes #8 - Remove API router dependence on @repo/db/schema job constants

## Workflow Routing
- #6: `Feature Delivery` (skills: `feature-delivery`, `intake-triage`, `test-surface-steward`)
- #7: `Feature Delivery` with architecture guard checks (skills: `feature-delivery`, `architecture-adr-guard`, `test-surface-steward`)
- #8: `Feature Delivery` with architecture boundary checks (skills: `feature-delivery`, `architecture-adr-guard`, `intake-triage`)

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Not applicable: no external paper trace required `research/implemented-ideas.md` update for this bundle.
