### PR TITLE
feat(queue): push run list order/limit into DB query

### DIFF
--- a/packages/api/src/server/use-cases/__tests__/runs.test.ts
+++ b/packages/api/src/server/use-cases/__tests__/runs.test.ts
@@ -116,22 +116,16 @@ describe('runs use-cases', () => {
     expect(error.message).toBe('queue unavailable');
   });
 
-  it('scopes list runs to user ownership and applies descending order + limit', async () => {
+  it('scopes list runs to user ownership and delegates order + limit to queue', async () => {
     let listUserId: string | undefined;
-    let listType: string | undefined;
+    let listOptions: Parameters<QueueService['getJobsByUser']>[1] | undefined;
 
     const queue = createMockQueueService({
-      getJobsByUser: (userId, type) => {
+      getJobsByUser: (userId, options) => {
         listUserId = userId;
-        listType = type;
+        listOptions = options;
 
         return Effect.succeed([
-          createJob({
-            id: 'job_old' as Job['id'],
-            payload: { prompt: 'older' },
-            createdAt: new Date('2026-02-20T00:00:00.000Z'),
-            updatedAt: new Date('2026-02-20T00:00:00.000Z'),
-          }),
           createJob({
             id: 'job_new' as Job['id'],
             payload: { prompt: 'newer' },
@@ -150,7 +144,11 @@ describe('runs use-cases', () => {
     );
 
     expect(listUserId).toBe(TEST_USER.id);
-    expect(listType).toBe(QueueJobType.PROCESS_AI_RUN);
+    expect(listOptions).toEqual({
+      type: QueueJobType.PROCESS_AI_RUN,
+      limit: 1,
+      sortByCreatedAt: 'desc',
+    });
     expect(runs).toHaveLength(1);
     expect(runs[0]?.id).toBe('job_new');
   });

--- a/packages/api/src/server/use-cases/runs.ts
+++ b/packages/api/src/server/use-cases/runs.ts
@@ -88,10 +88,11 @@ export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
 export const listRunsUseCase = ({ user, input }: ListRunsUseCaseInput) =>
   Effect.gen(function* () {
     const queue = yield* Queue;
-    const jobs = yield* queue.getJobsByUser(user.id, QueueJobType.PROCESS_AI_RUN);
-    const runs = jobs
-      .map((job) => toRunOutput(job as Job<RunPayload>))
-      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    const jobs = yield* queue.getJobsByUser(user.id, {
+      type: QueueJobType.PROCESS_AI_RUN,
+      limit: input.limit,
+      sortByCreatedAt: 'desc',
+    });
 
-    return input.limit ? runs.slice(0, input.limit) : runs;
+    return jobs.map((job) => toRunOutput(job as Job<RunPayload>));
   });

--- a/packages/db/drizzle/0001_rich_falcon.sql
+++ b/packages/db/drizzle/0001_rich_falcon.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "job_createdBy_type_createdAt_idx" ON "job" USING btree ("createdBy","type","createdAt");

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,568 @@
+{
+  "id": "a26e43d6-abe1-4284-b661-3991d8a5f198",
+  "prevId": "85afebdb-7906-494e-ae8c-e93a960cbe84",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job": {
+      "name": "job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_createdBy_idx": {
+          "name": "job_createdBy_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_createdBy_type_createdAt_idx": {
+          "name": "job_createdBy_type_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_type_status_idx": {
+          "name": "job_type_status_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_createdBy_user_id_fk": {
+          "name": "job_createdBy_user_id_fk",
+          "tableFrom": "job",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771869852378,
       "tag": "0000_mean_killmonger",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771879161707,
+      "tag": "0001_rich_falcon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schemas/jobs.ts
+++ b/packages/db/src/schemas/jobs.ts
@@ -51,6 +51,11 @@ export const job = pgTable(
   },
   (table) => [
     index('job_createdBy_idx').on(table.createdBy),
+    index('job_createdBy_type_createdAt_idx').on(
+      table.createdBy,
+      table.type,
+      table.createdAt,
+    ),
     index('job_status_idx').on(table.status),
     index('job_type_status_idx').on(table.type, table.status),
   ],

--- a/packages/queue/src/__tests__/claim-job.integration.test.ts
+++ b/packages/queue/src/__tests__/claim-job.integration.test.ts
@@ -162,6 +162,44 @@ describe.skipIf(!POSTGRES_URL)('Queue atomic job claim (integration)', () => {
     expect(processed!.id).toBe(first.id);
   });
 
+  it('lists jobs using explicit descending order and limit', async () => {
+    await runEffect(
+      Effect.flatMap(Queue, (q) =>
+        q.enqueue(JobType.PROCESS_AI_RUN, { order: 1 }, testUserId),
+      ),
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const second = await runEffect(
+      Effect.flatMap(Queue, (q) =>
+        q.enqueue(JobType.PROCESS_AI_RUN, { order: 2 }, testUserId),
+      ),
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const third = await runEffect(
+      Effect.flatMap(Queue, (q) =>
+        q.enqueue(JobType.PROCESS_AI_RUN, { order: 3 }, testUserId),
+      ),
+    );
+
+    const listed = await runEffect(
+      Effect.flatMap(Queue, (q) =>
+        q.getJobsByUser(testUserId, {
+          type: JobType.PROCESS_AI_RUN,
+          sortByCreatedAt: 'desc',
+          limit: 2,
+        }),
+      ),
+    );
+
+    expect(listed).toHaveLength(2);
+    expect(listed[0]!.id).toBe(third.id);
+    expect(listed[1]!.id).toBe(second.id);
+  });
+
   it('concurrent claims do not process the same job twice', async () => {
     // Enqueue a single job
     await runEffect(

--- a/packages/queue/src/repository.ts
+++ b/packages/queue/src/repository.ts
@@ -1,8 +1,8 @@
-import { eq, and, asc, sql } from '@repo/db';
+import { eq, and, asc, desc, sql } from '@repo/db';
 import { Db, withDb } from '@repo/db/effect';
 import { job, JobStatus } from '@repo/db/schema';
 import { Effect, Layer } from 'effect';
-import type { Job, JobType } from './types';
+import type { GetJobsByUserOptions, Job, JobType } from './types';
 import type { DatabaseInstance } from '@repo/db/client';
 import { QueueError, JobNotFoundError, JobProcessingError } from './errors';
 import { Queue, type QueueService } from './service';
@@ -113,18 +113,30 @@ const makeQueueService = Effect.gen(function* () {
       ),
     );
 
-  const getJobsByUser: QueueService['getJobsByUser'] = (userId, type) =>
+  const getJobsByUser: QueueService['getJobsByUser'] = (userId, options) =>
     runQuery(
       'getJobsByUser',
       async (db) => {
+        const {
+          type,
+          limit,
+          sortByCreatedAt = 'asc',
+        }: GetJobsByUserOptions = options ?? {};
         const conditions = [eq(job.createdBy, userId)];
         if (type) conditions.push(eq(job.type, type));
 
-        const rows = await db
+        const orderedQuery = db
           .select()
           .from(job)
           .where(and(...conditions))
-          .orderBy(asc(job.createdAt));
+          .orderBy(
+            sortByCreatedAt === 'desc' ? desc(job.createdAt) : asc(job.createdAt),
+          );
+
+        const rows =
+          typeof limit === 'number'
+            ? await orderedQuery.limit(limit)
+            : await orderedQuery;
 
         return rows.map(mapRowToJob);
       },

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -4,7 +4,12 @@ import type {
   JobNotFoundError,
   JobProcessingError,
 } from './errors';
-import type { Job, JobType, JobStatus } from './types';
+import type {
+  GetJobsByUserOptions,
+  Job,
+  JobType,
+  JobStatus,
+} from './types';
 import type { JobId } from '@repo/db/schema';
 import type { Effect } from 'effect';
 
@@ -21,7 +26,7 @@ export interface QueueService {
 
   readonly getJobsByUser: (
     userId: string,
-    type?: JobType,
+    options?: GetJobsByUserOptions,
   ) => Effect.Effect<Job[], QueueError>;
 
   readonly updateJobStatus: (

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -10,6 +10,13 @@ export const QueueJobType = {
 } as const;
 
 export type JobType = (typeof QueueJobType)[keyof typeof QueueJobType];
+export type JobSortOrder = 'asc' | 'desc';
+
+export interface GetJobsByUserOptions {
+  readonly type?: JobType;
+  readonly limit?: number;
+  readonly sortByCreatedAt?: JobSortOrder;
+}
 
 export interface Job<TPayload = unknown, TResult = unknown> {
   readonly id: JobId;


### PR DESCRIPTION
Fixes #10

## Summary
- extend queue `getJobsByUser` to accept typed query options (`type`, `limit`, `sortByCreatedAt`) and execute order/limit in SQL
- remove in-memory ordering/limiting from `listRunsUseCase` by delegating those semantics to the queue boundary
- add queue integration coverage for descending+limited reads and add a composite `job(createdBy, type, createdAt)` index with migration artifacts

## Aggregated Issues
- Fixes #10 (full resolution)

## Workflow Routing
- #10 -> Feature Delivery
  Skills: `feature-delivery`, `intake-triage`, `test-surface-steward`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Not applicable for this change set (no research trace/paper link adoption requiring `research/implemented-ideas.md` update).
