### PR TITLE
fix: explicit run-result decode failure handling for API and worker

### DIFF
--- a/apps/worker/src/__tests__/unified-worker.test.ts
+++ b/apps/worker/src/__tests__/unified-worker.test.ts
@@ -1,0 +1,87 @@
+import { JobStatus, JobType } from '@repo/db/schema';
+import { describe, expect, it, vi } from 'vitest';
+import type { RunResult, SSEEvent } from '@repo/api/contracts';
+import type { Job } from '@repo/queue';
+import {
+  handleCompletedRun,
+  INVALID_COMPLETED_RUN_RESULT_ERROR,
+} from '../unified-worker';
+
+type RunJobPayload = {
+  userId?: unknown;
+  prompt?: unknown;
+  threadId?: unknown;
+};
+
+const createJob = (
+  overrides: Partial<Job<RunJobPayload>> = {},
+): Job<RunJobPayload> => ({
+  id: 'job_test' as Job['id'],
+  type: JobType.PROCESS_AI_RUN,
+  status: JobStatus.COMPLETED,
+  payload: {
+    userId: 'user_test',
+    prompt: 'Plan project',
+    threadId: null,
+  },
+  result: null,
+  error: null,
+  createdBy: 'user_test',
+  createdAt: new Date('2026-02-23T00:00:00.000Z'),
+  updatedAt: new Date('2026-02-23T00:00:00.000Z'),
+  startedAt: new Date('2026-02-23T00:00:01.000Z'),
+  completedAt: new Date('2026-02-23T00:00:02.000Z'),
+  ...overrides,
+});
+
+describe('handleCompletedRun', () => {
+  it('emits run_completed for valid run results', () => {
+    const publishEvent = vi.fn<(userId: string, event: SSEEvent) => void>();
+    const result: RunResult = {
+      title: 'Title',
+      summary: 'Summary',
+      keyPoints: ['A', 'B'],
+      nextActions: ['C'],
+    };
+
+    handleCompletedRun(
+      publishEvent,
+      'user_test',
+      createJob({
+        result,
+      }),
+    );
+
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent).toHaveBeenCalledWith(
+      'user_test',
+      expect.objectContaining({
+        type: 'run_completed',
+        runId: 'job_test',
+        result,
+      }),
+    );
+  });
+
+  it('emits run_failed for completed jobs with invalid result payload', () => {
+    const publishEvent = vi.fn<(userId: string, event: SSEEvent) => void>();
+
+    handleCompletedRun(
+      publishEvent,
+      'user_test',
+      createJob({
+        result: { nope: 'invalid' },
+      }),
+    );
+
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent).toHaveBeenCalledWith(
+      'user_test',
+      expect.objectContaining({
+        type: 'run_failed',
+        runId: 'job_test',
+        error: INVALID_COMPLETED_RUN_RESULT_ERROR,
+      }),
+    );
+  });
+});

--- a/apps/worker/src/unified-worker.ts
+++ b/apps/worker/src/unified-worker.ts
@@ -34,6 +34,18 @@ type RunJobPayload = {
 const JOB_TYPES: QueueJobType[] = [JobType.PROCESS_AI_RUN];
 
 const decodeRunResult = Schema.decodeUnknownSync(RunResultSchema);
+export const INVALID_COMPLETED_RUN_RESULT_ERROR =
+  'Run completed with invalid result payload';
+const RUN_RESULT_DECODE_SOURCE_PATH =
+  'apps/worker/src/unified-worker.ts:onJobComplete';
+
+const toParseErrorSummary = (error: unknown): string => {
+  const message = formatError(error);
+  const firstLine = message.split('\n')[0]?.trim();
+  return firstLine && firstLine.length > 0
+    ? firstLine
+    : 'invalid run result payload';
+};
 
 const runSystemPrompt = `You are an async background AI assistant.
 
@@ -86,14 +98,59 @@ const decodePayload = (
   return Effect.succeed({ userId, prompt, threadId });
 };
 
-const parseRunResult = (value: unknown): RunResult | null => {
-  if (value == null) return null;
+type ParsedRunResult = {
+  readonly result: RunResult | null;
+  readonly parseErrorSummary: string | null;
+};
+
+const parseRunResult = (value: unknown): ParsedRunResult => {
+  if (value == null) {
+    return {
+      result: null,
+      parseErrorSummary: 'missing result payload',
+    };
+  }
 
   try {
-    return decodeRunResult(value);
-  } catch {
-    return null;
+    return {
+      result: decodeRunResult(value),
+      parseErrorSummary: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      parseErrorSummary: toParseErrorSummary(error),
+    };
   }
+};
+
+const logRunResultDecodeFailure = (jobId: string, parseErrorSummary: string) => {
+  Effect.runSync(
+    Effect.logWarning('run.result.decode_failed').pipe(
+      Effect.annotateLogs('queue.job.id', jobId),
+      Effect.annotateLogs('source.path', RUN_RESULT_DECODE_SOURCE_PATH),
+      Effect.annotateLogs('parse.error.summary', parseErrorSummary),
+    ),
+  );
+};
+
+export const handleCompletedRun = (
+  publishEvent: PublishEvent | undefined,
+  userId: string,
+  job: Job<RunJobPayload>,
+): void => {
+  const parsed = parseRunResult(job.result);
+
+  if (parsed.result) {
+    emitRunCompleted(publishEvent, userId, job.id, parsed.result);
+    return;
+  }
+
+  if (parsed.parseErrorSummary) {
+    logRunResultDecodeFailure(job.id, parsed.parseErrorSummary);
+  }
+
+  emitRunFailed(publishEvent, userId, job.id, INVALID_COMPLETED_RUN_RESULT_ERROR);
 };
 
 const processAiRunJob = (
@@ -178,10 +235,7 @@ export function createUnifiedWorker(config: UnifiedWorkerConfig): Worker {
         : job.createdBy;
 
     if (job.status === JobStatus.COMPLETED) {
-      const result = parseRunResult(job.result);
-      if (result) {
-        emitRunCompleted(config.publishEvent, userId, job.id, result);
-      }
+      handleCompletedRun(config.publishEvent, userId, job);
       return;
     }
 

--- a/packages/api/src/server/use-cases/__tests__/runs.test.ts
+++ b/packages/api/src/server/use-cases/__tests__/runs.test.ts
@@ -153,6 +153,33 @@ describe('runs use-cases', () => {
     expect(runs[0]?.id).toBe('job_new');
   });
 
+  it('surfaces deterministic error for completed runs with invalid result payload', async () => {
+    const queue = createMockQueueService({
+      getJobsByUser: () =>
+        Effect.succeed([
+          createJob({
+            id: 'job_invalid_result' as Job['id'],
+            status: 'completed',
+            result: {
+              not: 'a-run-result',
+            },
+            error: null,
+          }),
+        ]),
+    });
+
+    const runs = await Effect.runPromise(
+      listRunsUseCase({
+        user: TEST_USER,
+        input: {},
+      }).pipe(withQueue(queue)),
+    );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.result).toBeNull();
+    expect(runs[0]?.error).toBe('Run completed with invalid result payload');
+  });
+
   it('preserves typed queue errors for list run failures', async () => {
     const queueError = new QueueError({ message: 'query failed' });
     const queue = createMockQueueService({

--- a/packages/api/src/server/use-cases/runs.ts
+++ b/packages/api/src/server/use-cases/runs.ts
@@ -1,4 +1,4 @@
-import { Queue, QueueJobType, type Job } from '@repo/queue';
+import { Queue, QueueJobType, formatError, type Job } from '@repo/queue';
 import { Effect, Schema } from 'effect';
 import type { User } from '@repo/auth/policy';
 import {
@@ -29,32 +29,100 @@ export interface ListRunsUseCaseInput {
 }
 
 const decodeRunResult = Schema.decodeUnknownSync(RunResultSchema);
+const INVALID_COMPLETED_RUN_RESULT_ERROR =
+  'Run completed with invalid result payload';
+const CREATE_RUN_SOURCE_PATH =
+  'packages/api/src/server/use-cases/runs.ts:createRunUseCase';
+const LIST_RUNS_SOURCE_PATH =
+  'packages/api/src/server/use-cases/runs.ts:listRunsUseCase';
 
 const toOptionalString = (value: unknown): string | null =>
   typeof value === 'string' && value.trim().length > 0 ? value : null;
 
-const toRunResult = (value: unknown): RunResult | null => {
-  if (value == null) return null;
+type RunResultDecodeOutcome = {
+  readonly result: RunResult | null;
+  readonly parseErrorSummary: string | null;
+};
+
+const toParseErrorSummary = (error: unknown): string => {
+  const message = formatError(error);
+  const firstLine = message.split('\n')[0]?.trim();
+  return firstLine && firstLine.length > 0
+    ? firstLine
+    : 'invalid run result payload';
+};
+
+const decodeRunResultOutcome = (value: unknown): RunResultDecodeOutcome => {
+  if (value == null) {
+    return {
+      result: null,
+      parseErrorSummary: 'missing result payload',
+    };
+  }
 
   try {
-    return decodeRunResult(value);
-  } catch {
-    return null;
+    return {
+      result: decodeRunResult(value),
+      parseErrorSummary: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      parseErrorSummary: toParseErrorSummary(error),
+    };
   }
 };
 
-const toRunOutput = (job: Job<RunPayload>): RunOutput => ({
-  id: job.id,
-  status: job.status,
-  prompt: toOptionalString(job.payload?.prompt) ?? '',
-  threadId: toOptionalString(job.payload?.threadId),
-  result: toRunResult(job.result),
-  error: job.error,
-  createdAt: job.createdAt.toISOString(),
-  updatedAt: job.updatedAt.toISOString(),
-  startedAt: job.startedAt?.toISOString() ?? null,
-  completedAt: job.completedAt?.toISOString() ?? null,
-});
+const logRunResultDecodeFailure = (
+  jobId: string,
+  sourcePath: string,
+  parseErrorSummary: string,
+) =>
+  Effect.logWarning('run.result.decode_failed').pipe(
+    Effect.annotateLogs('queue.job.id', jobId),
+    Effect.annotateLogs('source.path', sourcePath),
+    Effect.annotateLogs('parse.error.summary', parseErrorSummary),
+  );
+
+const toRunOutput = (
+  job: Job<RunPayload>,
+  sourcePath: string,
+): Effect.Effect<RunOutput, never> =>
+  Effect.gen(function* () {
+    const decoded = decodeRunResultOutcome(job.result);
+    const isCompletedRunWithInvalidResult =
+      job.status === 'completed' && decoded.result === null;
+    const hasMalformedResult =
+      job.result != null && decoded.parseErrorSummary !== null;
+    const shouldLogDecodeFailure =
+      decoded.parseErrorSummary !== null &&
+      (isCompletedRunWithInvalidResult || hasMalformedResult);
+
+    if (shouldLogDecodeFailure) {
+      yield* logRunResultDecodeFailure(
+        job.id,
+        sourcePath,
+        decoded.parseErrorSummary,
+      );
+    }
+
+    return {
+      id: job.id,
+      status: job.status,
+      prompt: toOptionalString(job.payload?.prompt) ?? '',
+      threadId: toOptionalString(job.payload?.threadId),
+      result: decoded.result,
+      error:
+        job.error ??
+        (isCompletedRunWithInvalidResult
+          ? INVALID_COMPLETED_RUN_RESULT_ERROR
+          : null),
+      createdAt: job.createdAt.toISOString(),
+      updatedAt: job.updatedAt.toISOString(),
+      startedAt: job.startedAt?.toISOString() ?? null,
+      completedAt: job.completedAt?.toISOString() ?? null,
+    };
+  });
 
 export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
   Effect.gen(function* () {
@@ -70,7 +138,10 @@ export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
       user.id,
     );
 
-    const run = toRunOutput(created as Job<RunPayload>);
+    const run = yield* toRunOutput(
+      created as Job<RunPayload>,
+      CREATE_RUN_SOURCE_PATH,
+    );
 
     yield* Effect.sync(() =>
       ssePublisher.publish(user.id, {
@@ -94,5 +165,7 @@ export const listRunsUseCase = ({ user, input }: ListRunsUseCaseInput) =>
       sortByCreatedAt: 'desc',
     });
 
-    return jobs.map((job) => toRunOutput(job as Job<RunPayload>));
+    return yield* Effect.forEach(jobs, (job) =>
+      toRunOutput(job as Job<RunPayload>, LIST_RUNS_SOURCE_PATH),
+    );
   });


### PR DESCRIPTION
Fixes #11

## Summary
- replace silent run-result decode fallback with explicit decode-failure handling in API run serialization and worker completion handling
- emit structured warning logs for decode failures with stable attributes (`queue.job.id`, `source.path`, `parse.error.summary`)
- enforce deterministic behavior for completed jobs with invalid/missing result payloads by surfacing `Run completed with invalid result payload` and emitting `run_failed` from worker completion path
- add tests for API invalid-result serialization path and worker completed-job invalid-result behavior

## Aggregated Issues
- Fixes #11 (primary, fully resolved)

## Workflow Routing
- #11: Feature Delivery
  - Skills used: `feature-delivery`, `debug-fix`, `test-surface-steward`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`
