### PR TITLE
feat(queue): typed queue jobs and stale recovery wiring

### DIFF
--- a/apps/worker/src/__tests__/unified-worker.test.ts
+++ b/apps/worker/src/__tests__/unified-worker.test.ts
@@ -1,8 +1,14 @@
 import { JobStatus, JobType } from '@repo/db/schema';
+import { Queue, QueueError, type Job, type QueueService } from '@repo/queue';
+import { Effect, Layer } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 import type { RunResult, SSEEvent } from '@repo/api/contracts';
-import type { Job } from '@repo/queue';
 import {
+  STALE_CHECK_EVERY_N_POLLS,
+  STALE_JOB_MAX_AGE_MS,
+} from '../constants';
+import {
+  createStaleJobReaper,
   handleCompletedRun,
   INVALID_COMPLETED_RUN_RESULT_ERROR,
 } from '../unified-worker';
@@ -33,6 +39,24 @@ const createJob = (
   completedAt: new Date('2026-02-23T00:00:02.000Z'),
   ...overrides,
 });
+
+const createMockQueueService = (
+  overrides: Partial<QueueService> = {},
+): QueueService => ({
+  enqueue: () => Effect.die('enqueue not mocked'),
+  getJob: () => Effect.die('getJob not mocked'),
+  getJobsByUser: () => Effect.die('getJobsByUser not mocked'),
+  updateJobStatus: () => Effect.die('updateJobStatus not mocked'),
+  processNextJob: () => Effect.die('processNextJob not mocked'),
+  processJobById: () => Effect.die('processJobById not mocked'),
+  claimNextJob: () => Effect.die('claimNextJob not mocked'),
+  deleteJob: () => Effect.die('deleteJob not mocked'),
+  failStaleJobs: () => Effect.die('failStaleJobs not mocked'),
+  ...overrides,
+});
+
+const withQueue = (queue: QueueService) =>
+  Effect.provide(Layer.succeed(Queue, queue));
 
 describe('handleCompletedRun', () => {
   it('emits run_completed for valid run results', () => {
@@ -83,5 +107,70 @@ describe('handleCompletedRun', () => {
         error: INVALID_COMPLETED_RUN_RESULT_ERROR,
       }),
     );
+  });
+});
+
+describe('createStaleJobReaper', () => {
+  it('skips stale checks before the configured poll cadence', async () => {
+    let failStaleJobsCalls = 0;
+    const queue = createMockQueueService({
+      failStaleJobs: () => {
+        failStaleJobsCalls += 1;
+        return Effect.succeed({
+          checkedCount: 0,
+          affectedCount: 0,
+          jobs: [],
+        });
+      },
+    });
+
+    await Effect.runPromise(
+      createStaleJobReaper()(STALE_CHECK_EVERY_N_POLLS - 1).pipe(withQueue(queue)),
+    );
+
+    expect(failStaleJobsCalls).toBe(0);
+  });
+
+  it('runs stale checks on cadence using default max-age configuration', async () => {
+    let receivedMaxAgeMs: number | null = null;
+    const queue = createMockQueueService({
+      failStaleJobs: (maxAgeMs) => {
+        receivedMaxAgeMs = maxAgeMs;
+        return Effect.succeed({
+          checkedCount: 2,
+          affectedCount: 1,
+          jobs: [
+            createJob({
+              status: JobStatus.FAILED,
+              error: 'Job timed out: worker did not complete within 3600s',
+            }),
+          ],
+        });
+      },
+    });
+
+    await Effect.runPromise(
+      createStaleJobReaper()(STALE_CHECK_EVERY_N_POLLS).pipe(withQueue(queue)),
+    );
+
+    expect(receivedMaxAgeMs).toBe(STALE_JOB_MAX_AGE_MS);
+  });
+
+  it('swallows queue failures so worker polling can continue', async () => {
+    let failStaleJobsCalls = 0;
+    const queue = createMockQueueService({
+      failStaleJobs: () => {
+        failStaleJobsCalls += 1;
+        return Effect.fail(new QueueError({ message: 'queue unavailable' }));
+      },
+    });
+
+    await expect(
+      Effect.runPromise(
+        createStaleJobReaper()(STALE_CHECK_EVERY_N_POLLS).pipe(withQueue(queue)),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(failStaleJobsCalls).toBe(1);
   });
 });

--- a/apps/worker/src/unified-worker.ts
+++ b/apps/worker/src/unified-worker.ts
@@ -3,6 +3,7 @@ import { type RunResult, RunResultSchema } from '@repo/api/contracts';
 import { JobStatus, JobType } from '@repo/db/schema';
 import {
   JobProcessingError,
+  Queue,
   formatError,
   type Job,
   type JobType as QueueJobType,
@@ -13,6 +14,10 @@ import {
   type BaseWorkerConfig,
   type Worker,
 } from './base-worker';
+import {
+  STALE_CHECK_EVERY_N_POLLS,
+  STALE_JOB_MAX_AGE_MS,
+} from './constants';
 import {
   emitRunCompleted,
   emitRunFailed,
@@ -38,6 +43,8 @@ export const INVALID_COMPLETED_RUN_RESULT_ERROR =
   'Run completed with invalid result payload';
 const RUN_RESULT_DECODE_SOURCE_PATH =
   'apps/worker/src/unified-worker.ts:onJobComplete';
+const STALE_REAPER_SOURCE_PATH =
+  'apps/worker/src/unified-worker.ts:onPollCycle';
 
 const toParseErrorSummary = (error: unknown): string => {
   const message = formatError(error);
@@ -153,6 +160,57 @@ export const handleCompletedRun = (
   emitRunFailed(publishEvent, userId, job.id, INVALID_COMPLETED_RUN_RESULT_ERROR);
 };
 
+const shouldRunStaleCheck = (pollCount: number, checkEveryNPolls: number) =>
+  pollCount > 0 && pollCount % checkEveryNPolls === 0;
+
+export const createStaleJobReaper = (
+  maxAgeMs = STALE_JOB_MAX_AGE_MS,
+  checkEveryNPolls = STALE_CHECK_EVERY_N_POLLS,
+) =>
+  (pollCount: number) =>
+    shouldRunStaleCheck(pollCount, checkEveryNPolls)
+      ? Effect.gen(function* () {
+          const queue = yield* Queue;
+          const sweep = yield* queue.failStaleJobs(maxAgeMs).pipe(
+            Effect.catchAll((error) =>
+              Effect.logError('worker.stale_job_reaper.failed').pipe(
+                Effect.annotateLogs('source.path', STALE_REAPER_SOURCE_PATH),
+                Effect.annotateLogs('worker.poll.count', pollCount),
+                Effect.annotateLogs('queue.stale_jobs.max_age_ms', maxAgeMs),
+                Effect.annotateLogs(
+                  'queue.stale_jobs.check_every_n_polls',
+                  checkEveryNPolls,
+                ),
+                Effect.annotateLogs('error.message', formatError(error)),
+                Effect.as(null),
+              ),
+            ),
+          );
+
+          if (!sweep) {
+            return;
+          }
+
+          yield* Effect.logInfo('worker.stale_job_reaper.completed').pipe(
+            Effect.annotateLogs('source.path', STALE_REAPER_SOURCE_PATH),
+            Effect.annotateLogs('worker.poll.count', pollCount),
+            Effect.annotateLogs('queue.stale_jobs.max_age_ms', maxAgeMs),
+            Effect.annotateLogs(
+              'queue.stale_jobs.check_every_n_polls',
+              checkEveryNPolls,
+            ),
+            Effect.annotateLogs(
+              'queue.stale_jobs.checked_count',
+              sweep.checkedCount,
+            ),
+            Effect.annotateLogs(
+              'queue.stale_jobs.affected_count',
+              sweep.affectedCount,
+            ),
+          );
+        })
+      : Effect.void;
+
 const processAiRunJob = (
   job: Job<RunJobPayload>,
   publishEvent: PublishEvent | undefined,
@@ -255,6 +313,7 @@ export function createUnifiedWorker(config: UnifiedWorkerConfig): Worker {
     config,
     processJob,
     onStart,
+    onPollCycle: createStaleJobReaper(),
     onJobComplete,
   });
 }

--- a/docs/patterns/job-queue.md
+++ b/docs/patterns/job-queue.md
@@ -5,10 +5,12 @@
 1. API enqueues `process-ai-run` jobs.
 2. Worker claims pending jobs in FIFO order.
 3. Worker updates status: `pending -> processing -> completed|failed`.
-4. Worker publishes SSE progress/completion events.
+4. Worker periodically reaps stale `processing` jobs to `failed`.
+5. Worker publishes SSE progress/completion events.
 
 ## Queue Safety Rules
 
 - Claim atomically with `FOR UPDATE SKIP LOCKED`.
 - Write terminal status on any failure path.
+- Reap stale `processing` jobs on poll cadence and log checked/affected counts.
 - Record timestamps for start/completion.

--- a/packages/api/src/server/use-cases/__tests__/runs.test.ts
+++ b/packages/api/src/server/use-cases/__tests__/runs.test.ts
@@ -2,8 +2,10 @@ import {
   Queue,
   QueueError,
   QueueJobType,
-  type Job,
+  type JobPayload,
+  type JobResult,
   type QueueService,
+  type TypedJob,
 } from '@repo/queue';
 import { Effect, Layer } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -17,6 +19,10 @@ const TEST_USER: User = {
   name: 'Test User',
   role: 'user',
 };
+
+type RunJob = TypedJob<typeof QueueJobType.PROCESS_AI_RUN>;
+type RunPayload = JobPayload<typeof QueueJobType.PROCESS_AI_RUN>;
+type RunResult = JobResult<typeof QueueJobType.PROCESS_AI_RUN>;
 
 const createMockQueueService = (
   overrides: Partial<QueueService> = {},
@@ -33,12 +39,16 @@ const createMockQueueService = (
   ...overrides,
 });
 
-const createJob = (overrides: Partial<Job> = {}): Job => ({
-  id: 'job_test' as Job['id'],
+const createJob = (overrides: Partial<RunJob> = {}): RunJob => ({
+  id: 'job_test' as RunJob['id'],
   type: QueueJobType.PROCESS_AI_RUN,
   status: 'pending',
-  payload: {},
-  result: null,
+  payload: {
+    prompt: 'default prompt',
+    userId: TEST_USER.id,
+    threadId: null,
+  },
+  result: null as RunResult | null,
   error: null,
   createdBy: TEST_USER.id,
   createdAt: new Date('2026-02-23T00:00:00.000Z'),
@@ -61,12 +71,14 @@ describe('runs use-cases', () => {
     let enqueueUserId: string | undefined;
 
     const queue = createMockQueueService({
-      enqueue: (type, payload, userId) => {
+      enqueue: ((type, payload, userId) => {
         enqueueType = type;
         enqueuePayload = payload;
         enqueueUserId = userId;
-        return Effect.succeed(createJob({ payload }));
-      },
+        return Effect.succeed(
+          createJob({ payload: payload as RunPayload }),
+        ) as ReturnType<QueueService['enqueue']>;
+      }) as QueueService['enqueue'],
     });
 
     const publishSpy = vi
@@ -121,19 +133,23 @@ describe('runs use-cases', () => {
     let listOptions: Parameters<QueueService['getJobsByUser']>[1] | undefined;
 
     const queue = createMockQueueService({
-      getJobsByUser: (userId, options) => {
+      getJobsByUser: ((userId, options) => {
         listUserId = userId;
         listOptions = options;
 
         return Effect.succeed([
           createJob({
-            id: 'job_new' as Job['id'],
-            payload: { prompt: 'newer' },
+            id: 'job_new' as RunJob['id'],
+            payload: {
+              prompt: 'newer',
+              userId: TEST_USER.id,
+              threadId: null,
+            },
             createdAt: new Date('2026-02-22T00:00:00.000Z'),
             updatedAt: new Date('2026-02-22T00:00:00.000Z'),
           }),
-        ]);
-      },
+        ]) as ReturnType<QueueService['getJobsByUser']>;
+      }) as QueueService['getJobsByUser'],
     });
 
     const runs = await Effect.runPromise(
@@ -155,17 +171,17 @@ describe('runs use-cases', () => {
 
   it('surfaces deterministic error for completed runs with invalid result payload', async () => {
     const queue = createMockQueueService({
-      getJobsByUser: () =>
+      getJobsByUser: (() =>
         Effect.succeed([
           createJob({
-            id: 'job_invalid_result' as Job['id'],
+            id: 'job_invalid_result' as RunJob['id'],
             status: 'completed',
             result: {
               not: 'a-run-result',
-            },
+            } as unknown as RunResult,
             error: null,
           }),
-        ]),
+        ])) as QueueService['getJobsByUser'],
     });
 
     const runs = await Effect.runPromise(

--- a/packages/api/src/server/use-cases/runs.ts
+++ b/packages/api/src/server/use-cases/runs.ts
@@ -1,4 +1,9 @@
-import { Queue, QueueJobType, formatError, type Job } from '@repo/queue';
+import {
+  Queue,
+  QueueJobType,
+  formatError,
+  type TypedJob,
+} from '@repo/queue';
 import { Effect, Schema } from 'effect';
 import type { User } from '@repo/auth/policy';
 import {
@@ -9,10 +14,7 @@ import {
 } from '../../contracts/runs';
 import { ssePublisher } from '../publisher';
 
-type RunPayload = {
-  prompt?: unknown;
-  threadId?: unknown;
-};
+type RunJob = TypedJob<typeof QueueJobType.PROCESS_AI_RUN>;
 
 type ListRunsInput = {
   readonly limit?: number;
@@ -85,11 +87,11 @@ const logRunResultDecodeFailure = (
   );
 
 const toRunOutput = (
-  job: Job<RunPayload>,
+  job: RunJob,
   sourcePath: string,
 ): Effect.Effect<RunOutput, never> =>
   Effect.gen(function* () {
-    const decoded = decodeRunResultOutcome(job.result);
+    const decoded = decodeRunResultOutcome(job.result as unknown);
     const isCompletedRunWithInvalidResult =
       job.status === 'completed' && decoded.result === null;
     const hasMalformedResult =
@@ -139,7 +141,7 @@ export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
     );
 
     const run = yield* toRunOutput(
-      created as Job<RunPayload>,
+      created,
       CREATE_RUN_SOURCE_PATH,
     );
 
@@ -166,6 +168,6 @@ export const listRunsUseCase = ({ user, input }: ListRunsUseCaseInput) =>
     });
 
     return yield* Effect.forEach(jobs, (job) =>
-      toRunOutput(job as Job<RunPayload>, LIST_RUNS_SOURCE_PATH),
+      toRunOutput(job, LIST_RUNS_SOURCE_PATH),
     );
   });

--- a/packages/queue/src/__tests__/claim-job.integration.test.ts
+++ b/packages/queue/src/__tests__/claim-job.integration.test.ts
@@ -6,7 +6,7 @@ import { user } from '@repo/db/schema';
 import { Effect, Layer } from 'effect';
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { JobProcessingError } from '../errors';
-import { QueueLive } from '../repository';
+import { QueueLive, toStaleJobTimeoutError } from '../repository';
 import { Queue } from '../service';
 
 /**
@@ -233,5 +233,44 @@ describe.skipIf(!POSTGRES_URL)('Queue atomic job claim (integration)', () => {
     expect(claimed).toHaveLength(1);
     expect(missed).toHaveLength(1);
     expect(claimed[0]!.status).toBe(JobStatus.COMPLETED);
+  });
+
+  it('fails stale processing jobs with deterministic timeout errors', async () => {
+    const enqueued = await runEffect(
+      Effect.flatMap(Queue, (q) =>
+        q.enqueue(JobType.PROCESS_AI_RUN, { stale: true }, testUserId),
+      ),
+    );
+
+    const startedAt = new Date(Date.now() - 90_000);
+    await db
+      .update(job)
+      .set({
+        status: JobStatus.PROCESSING,
+        startedAt,
+        updatedAt: startedAt,
+      })
+      .where(eq(job.id, enqueued.id));
+
+    const maxAgeMs = 60_000;
+    const sweep = await runEffect(
+      Effect.flatMap(Queue, (q) => q.failStaleJobs(maxAgeMs)),
+    );
+
+    expect(sweep.checkedCount).toBe(1);
+    expect(sweep.affectedCount).toBe(1);
+    expect(sweep.jobs).toHaveLength(1);
+    expect(sweep.jobs[0]?.id).toBe(enqueued.id);
+    expect(sweep.jobs[0]?.status).toBe(JobStatus.FAILED);
+    expect(sweep.jobs[0]?.error).toBe(toStaleJobTimeoutError(maxAgeMs));
+
+    const [updated] = await db
+      .select()
+      .from(job)
+      .where(eq(job.id, enqueued.id))
+      .limit(1);
+
+    expect(updated?.status).toBe(JobStatus.FAILED);
+    expect(updated?.error).toBe(toStaleJobTimeoutError(maxAgeMs));
   });
 });

--- a/packages/queue/src/__tests__/job-type-parity.test.ts
+++ b/packages/queue/src/__tests__/job-type-parity.test.ts
@@ -1,0 +1,25 @@
+import { JobType } from '@repo/db/schema';
+import { describe, expect, it } from 'vitest';
+import {
+  QueueJobType,
+  type QueueJobMapCoversAllJobTypes,
+  type QueueJobMapHasNoExtraJobTypes,
+} from '../types';
+
+describe('queue job-type parity', () => {
+  it('reuses db job-type constants', () => {
+    expect(QueueJobType).toBe(JobType);
+  });
+
+  it('keeps queue and db job-type values aligned', () => {
+    expect(Object.values(QueueJobType)).toEqual(Object.values(JobType));
+  });
+
+  it('enforces typed queue map coverage for all job types', () => {
+    const coversAll: QueueJobMapCoversAllJobTypes = true;
+    const hasNoExtra: QueueJobMapHasNoExtraJobTypes = true;
+
+    expect(coversAll).toBe(true);
+    expect(hasNoExtra).toBe(true);
+  });
+});

--- a/packages/queue/src/repository.ts
+++ b/packages/queue/src/repository.ts
@@ -2,18 +2,36 @@ import { eq, and, asc, desc, sql } from '@repo/db';
 import { Db, withDb } from '@repo/db/effect';
 import { job, JobStatus } from '@repo/db/schema';
 import { Effect, Layer } from 'effect';
-import type { GetJobsByUserOptions, Job, JobType } from './types';
+import type {
+  GetJobsByUserOptions,
+  Job,
+  JobPayload,
+  JobResult,
+  JobType,
+  StaleJobSweepResult,
+  TypedJob,
+} from './types';
 import type { DatabaseInstance } from '@repo/db/client';
 import { QueueError, JobNotFoundError, JobProcessingError } from './errors';
 import { Queue, type QueueService } from './service';
 
 type JobRow = typeof job.$inferSelect;
+type CountRow = { count: number | string };
 
-const mapRowToJob = (row: JobRow): Job => ({
+const mapRowToJob = <TType extends JobType = JobType>(
+  row: JobRow,
+): TypedJob<TType> => ({
   ...row,
-  type: row.type as JobType,
-  payload: row.payload ?? {},
+  type: row.type as TType,
+  payload: (row.payload ?? {}) as unknown as JobPayload<TType>,
+  result: (row.result ?? null) as JobResult<TType> | null,
 });
+
+const intervalSecondsFromMs = (maxAgeMs: number): number =>
+  Math.max(1, Math.floor(maxAgeMs / 1000));
+
+export const toStaleJobTimeoutError = (maxAgeMs: number): string =>
+  `Job timed out: worker did not complete within ${intervalSecondsFromMs(maxAgeMs)}s`;
 
 const makeQueueService = Effect.gen(function* () {
   const { db } = yield* Db;
@@ -37,14 +55,21 @@ const makeQueueService = Effect.gen(function* () {
       }),
     );
 
+  const castTypedJob = <TType extends JobType>(updated: Job): TypedJob<TType> =>
+    updated as TypedJob<TType>;
+
   /** Run handler then mark completed or failed. Assumes job is already PROCESSING. */
-  const runHandler = <R>(
-    claimed: Job,
-    handler: (job: Job) => Effect.Effect<unknown, JobProcessingError, R>,
+  const runHandler = <TType extends JobType, R>(
+    claimed: TypedJob<TType>,
+    handler: (
+      job: TypedJob<TType>,
+    ) => Effect.Effect<unknown, JobProcessingError, R>,
   ) =>
     handler(claimed).pipe(
       Effect.flatMap((result) =>
-        updateJobStatus(claimed.id, JobStatus.COMPLETED, result),
+        updateJobStatus(claimed.id, JobStatus.COMPLETED, result).pipe(
+          Effect.map(castTypedJob<TType>),
+        ),
       ),
       Effect.catchAll((err) =>
         updateJobStatus(
@@ -52,7 +77,7 @@ const makeQueueService = Effect.gen(function* () {
           JobStatus.FAILED,
           undefined,
           err instanceof JobProcessingError ? err.message : String(err),
-        ),
+        ).pipe(Effect.map(castTypedJob<TType>)),
       ),
       Effect.catchAllDefect((defect) =>
         updateJobStatus(
@@ -60,11 +85,15 @@ const makeQueueService = Effect.gen(function* () {
           JobStatus.FAILED,
           undefined,
           `Unexpected defect: ${defect instanceof Error ? defect.message : String(defect)}`,
-        ),
+        ).pipe(Effect.map(castTypedJob<TType>)),
       ),
     );
 
-  const enqueue: QueueService['enqueue'] = (type, payload, userId) =>
+  const enqueue = <TType extends JobType>(
+    type: TType,
+    payload: JobPayload<TType>,
+    userId: string,
+  ): Effect.Effect<TypedJob<TType>, QueueError> =>
     runQuery(
       'enqueue',
       async (db) => {
@@ -72,14 +101,14 @@ const makeQueueService = Effect.gen(function* () {
           .insert(job)
           .values({
             type,
-            payload: payload as Record<string, unknown>,
+            payload: payload as unknown as Record<string, unknown>,
             createdBy: userId,
           })
           .returning();
 
         if (!row) throw new Error('Failed to insert job');
 
-        return mapRowToJob(row);
+        return mapRowToJob<TType>(row);
       },
       'Failed to enqueue job',
     ).pipe(
@@ -113,15 +142,18 @@ const makeQueueService = Effect.gen(function* () {
       ),
     );
 
-  const getJobsByUser: QueueService['getJobsByUser'] = (userId, options) =>
+  const getJobsByUser = <TType extends JobType = JobType>(
+    userId: string,
+    options?: GetJobsByUserOptions<TType>,
+  ): Effect.Effect<TypedJob<TType>[], QueueError> =>
     runQuery(
       'getJobsByUser',
       async (db) => {
         const {
           type,
           limit,
-          sortByCreatedAt = 'asc',
-        }: GetJobsByUserOptions = options ?? {};
+          sortByCreatedAt = 'asc' as const,
+        } = options ?? {};
         const conditions = [eq(job.createdBy, userId)];
         if (type) conditions.push(eq(job.type, type));
 
@@ -138,7 +170,7 @@ const makeQueueService = Effect.gen(function* () {
             ? await orderedQuery.limit(limit)
             : await orderedQuery;
 
-        return rows.map(mapRowToJob);
+        return rows.map((row) => mapRowToJob<TType>(row));
       },
       'Failed to get jobs',
     ).pipe(
@@ -195,7 +227,9 @@ const makeQueueService = Effect.gen(function* () {
       ),
     );
 
-  const claimNextJob = (type: JobType): Effect.Effect<Job | null, QueueError> =>
+  const claimNextJob = <TType extends JobType>(
+    type: TType,
+  ): Effect.Effect<TypedJob<TType> | null, QueueError> =>
     runQuery(
       'claimNextJob',
       async (db) => {
@@ -216,14 +250,23 @@ const makeQueueService = Effect.gen(function* () {
         `);
 
         const row = result.rows[0];
-        return row ? mapRowToJob(row as JobRow) : null;
+        return row ? mapRowToJob<TType>(row as JobRow) : null;
       },
       'Failed to claim next job',
     ).pipe(
       Effect.tap(() => Effect.annotateCurrentSpan('queue.job.type', type)),
     );
 
-  const processNextJob: QueueService['processNextJob'] = (type, handler) =>
+  const processNextJob = <TType extends JobType, R = never>(
+    type: TType,
+    handler: (
+      job: TypedJob<TType>,
+    ) => Effect.Effect<unknown, JobProcessingError, R>,
+  ): Effect.Effect<
+    TypedJob<TType> | null,
+    QueueError | JobProcessingError | JobNotFoundError,
+    R
+  > =>
     claimNextJob(type).pipe(
       Effect.flatMap((claimed) =>
         claimed ? runHandler(claimed, handler) : Effect.succeed(null),
@@ -236,33 +279,65 @@ const makeQueueService = Effect.gen(function* () {
         if (jobData.status !== JobStatus.PENDING)
           return Effect.succeed(jobData);
         return updateJobStatus(jobData.id, JobStatus.PROCESSING).pipe(
-          Effect.flatMap((updatedJob) => runHandler(updatedJob, handler)),
+          Effect.flatMap((updatedJob) =>
+            runHandler(
+              updatedJob as TypedJob<JobType>,
+              handler as (
+                job: TypedJob<JobType>,
+              ) => Effect.Effect<unknown, JobProcessingError>,
+            ),
+          ),
+          Effect.map((updatedJob) => updatedJob as Job),
         );
       }),
     );
 
-  const failStaleJobs: QueueService['failStaleJobs'] = (maxAgeMs) =>
+  const failStaleJobs = (
+    maxAgeMs: number,
+  ): Effect.Effect<StaleJobSweepResult, QueueError> =>
     runQuery(
       'failStaleJobs',
       async (db) => {
-        const intervalSeconds = Math.floor(maxAgeMs / 1000);
+        const intervalSeconds = intervalSecondsFromMs(maxAgeMs);
+        const timeoutError = toStaleJobTimeoutError(maxAgeMs);
+        const staleCondition = sql`${job.status} = ${JobStatus.PROCESSING}
+          AND ${job.startedAt} < NOW() - INTERVAL '${sql.raw(String(intervalSeconds))} seconds'`;
+
+        const countResult = await db.execute(sql`
+          SELECT COUNT(*)::int AS count
+          FROM ${job}
+          WHERE ${staleCondition}
+        `);
+
+        const checkedCount = Number(
+          (countResult.rows[0] as CountRow | undefined)?.count ?? 0,
+        );
+
         const result = await db.execute(sql`
           UPDATE ${job}
           SET "status" = ${JobStatus.FAILED},
-              "error" = ${'Job timed out: worker did not complete within ' + intervalSeconds + 's'},
+              "error" = ${timeoutError},
               "completedAt" = NOW(),
               "updatedAt" = NOW()
-          WHERE ${job.status} = ${JobStatus.PROCESSING}
-            AND ${job.startedAt} < NOW() - INTERVAL '${sql.raw(String(intervalSeconds))} seconds'
+          WHERE ${staleCondition}
           RETURNING *
         `);
 
-        return (result.rows as JobRow[]).map(mapRowToJob);
+        const jobs = (result.rows as JobRow[]).map((row) => mapRowToJob(row));
+
+        return {
+          checkedCount,
+          affectedCount: jobs.length,
+          jobs,
+        } satisfies StaleJobSweepResult;
       },
       'Failed to fail stale jobs',
     ).pipe(
-      Effect.tap((jobs) =>
-        Effect.annotateCurrentSpan('queue.stale_jobs.count', jobs.length),
+      Effect.tap((sweep) =>
+        Effect.annotateCurrentSpan({
+          'queue.stale_jobs.checked_count': sweep.checkedCount,
+          'queue.stale_jobs.affected_count': sweep.affectedCount,
+        }),
       ),
     );
 

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -7,27 +7,30 @@ import type {
 import type {
   GetJobsByUserOptions,
   Job,
+  JobPayload,
   JobType,
   JobStatus,
+  StaleJobSweepResult,
+  TypedJob,
 } from './types';
 import type { JobId } from '@repo/db/schema';
 import type { Effect } from 'effect';
 
 export interface QueueService {
-  readonly enqueue: (
-    type: JobType,
-    payload: unknown,
+  readonly enqueue: <TType extends JobType>(
+    type: TType,
+    payload: JobPayload<TType>,
     userId: string,
-  ) => Effect.Effect<Job, QueueError>;
+  ) => Effect.Effect<TypedJob<TType>, QueueError>;
 
   readonly getJob: (
     jobId: JobId,
   ) => Effect.Effect<Job, QueueError | JobNotFoundError>;
 
-  readonly getJobsByUser: (
+  readonly getJobsByUser: <TType extends JobType = JobType>(
     userId: string,
-    options?: GetJobsByUserOptions,
-  ) => Effect.Effect<Job[], QueueError>;
+    options?: GetJobsByUserOptions<TType>,
+  ) => Effect.Effect<TypedJob<TType>[], QueueError>;
 
   readonly updateJobStatus: (
     jobId: JobId,
@@ -36,11 +39,13 @@ export interface QueueService {
     error?: string,
   ) => Effect.Effect<Job, QueueError | JobNotFoundError>;
 
-  readonly processNextJob: <R = never>(
-    type: JobType,
-    handler: (job: Job) => Effect.Effect<unknown, JobProcessingError, R>,
+  readonly processNextJob: <TType extends JobType, R = never>(
+    type: TType,
+    handler: (
+      job: TypedJob<TType>,
+    ) => Effect.Effect<unknown, JobProcessingError, R>,
   ) => Effect.Effect<
-    Job | null,
+    TypedJob<TType> | null,
     QueueError | JobProcessingError | JobNotFoundError,
     R
   >;
@@ -54,9 +59,9 @@ export interface QueueService {
     R
   >;
 
-  readonly claimNextJob: (
-    type: JobType,
-  ) => Effect.Effect<Job | null, QueueError>;
+  readonly claimNextJob: <TType extends JobType>(
+    type: TType,
+  ) => Effect.Effect<TypedJob<TType> | null, QueueError>;
 
   readonly deleteJob: (
     jobId: JobId,
@@ -64,7 +69,7 @@ export interface QueueService {
 
   readonly failStaleJobs: (
     maxAgeMs: number,
-  ) => Effect.Effect<Job[], QueueError>;
+  ) => Effect.Effect<StaleJobSweepResult, QueueError>;
 }
 
 export class Queue extends Context.Tag('@repo/queue/Queue')<

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -1,3 +1,4 @@
+import { JobType as DbJobType } from '@repo/db/schema';
 import type {
   JobId,
   JobStatus as DbJobStatus,
@@ -5,32 +6,10 @@ import type {
 
 export type JobStatus = DbJobStatus;
 
-export const QueueJobType = {
-  PROCESS_AI_RUN: 'process-ai-run',
-} as const;
+export const QueueJobType = DbJobType;
 
 export type JobType = (typeof QueueJobType)[keyof typeof QueueJobType];
 export type JobSortOrder = 'asc' | 'desc';
-
-export interface GetJobsByUserOptions {
-  readonly type?: JobType;
-  readonly limit?: number;
-  readonly sortByCreatedAt?: JobSortOrder;
-}
-
-export interface Job<TPayload = unknown, TResult = unknown> {
-  readonly id: JobId;
-  readonly type: JobType;
-  readonly status: JobStatus;
-  readonly payload: TPayload;
-  readonly result: TResult | null;
-  readonly error: string | null;
-  readonly createdBy: string;
-  readonly createdAt: Date;
-  readonly updatedAt: Date;
-  readonly startedAt: Date | null;
-  readonly completedAt: Date | null;
-}
 
 export interface ProcessAiRunPayload {
   readonly userId: string;
@@ -43,4 +22,62 @@ export interface ProcessAiRunResult {
   readonly summary: string;
   readonly keyPoints: readonly string[];
   readonly nextActions: readonly string[];
+}
+
+export type QueueJobMap = {
+  readonly [QueueJobType.PROCESS_AI_RUN]: {
+    readonly payload: ProcessAiRunPayload;
+    readonly result: ProcessAiRunResult;
+  };
+};
+
+type MissingQueueJobMapEntries = Exclude<JobType, keyof QueueJobMap>;
+type ExtraQueueJobMapEntries = Exclude<keyof QueueJobMap, JobType>;
+
+type Assert<T extends true> = T;
+
+export type QueueJobMapCoversAllJobTypes = Assert<
+  MissingQueueJobMapEntries extends never ? true : false
+>;
+export type QueueJobMapHasNoExtraJobTypes = Assert<
+  ExtraQueueJobMapEntries extends never ? true : false
+>;
+
+export type JobPayload<TType extends JobType> = QueueJobMap[TType]['payload'];
+export type JobResult<TType extends JobType> = QueueJobMap[TType]['result'];
+
+export interface GetJobsByUserOptions<TType extends JobType = JobType> {
+  readonly type?: TType;
+  readonly limit?: number;
+  readonly sortByCreatedAt?: JobSortOrder;
+}
+
+export interface Job<
+  TPayload = unknown,
+  TResult = unknown,
+  TType extends JobType = JobType,
+> {
+  readonly id: JobId;
+  readonly type: TType;
+  readonly status: JobStatus;
+  readonly payload: TPayload;
+  readonly result: TResult | null;
+  readonly error: string | null;
+  readonly createdBy: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly startedAt: Date | null;
+  readonly completedAt: Date | null;
+}
+
+export type TypedJob<TType extends JobType> = Job<
+  JobPayload<TType>,
+  JobResult<TType>,
+  TType
+>;
+
+export interface StaleJobSweepResult {
+  readonly checkedCount: number;
+  readonly affectedCount: number;
+  readonly jobs: readonly Job[];
 }


### PR DESCRIPTION
## Summary
- unify queue job-type constants with DB constants to prevent drift
- add typed queue job map coverage checks and remove `as Job<...>` casts from runs use-cases
- wire stale-job reaping into unified worker poll lifecycle with checked/affected telemetry logs
- add parity and stale-transition tests, plus worker stale-reaper behavior tests

## Aggregated Issues
- Fixes #12 - Add queue job-type parity guardrail and typed job maps
- Fixes #13 - Wire stale-job recovery into worker poll loop

## Workflow Routing
- #12 -> Feature Delivery (`feature-delivery`) + companion skills: `intake-triage`, `test-surface-steward`
- #13 -> Feature Delivery (`feature-delivery`) + companion skills: `intake-triage`, `test-surface-steward`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Not applicable (no external paper links in selected issues).

Fixes #12
Fixes #13
