### PR TITLE
feat: add structured scan metadata to workflow-memory events

### DIFF
--- a/agent-engine/automations/best-practice-researcher/best-practice-researcher.md
+++ b/agent-engine/automations/best-practice-researcher/best-practice-researcher.md
@@ -81,8 +81,13 @@ Append concise run memory including:
 - related issues and new issue URLs
 - signal score 1-5
 - followability delta
+- structured scan metadata for Periodic Scans events:
+  - `--scan-walk-mode`
+  - `--scan-scope`
+  - `--scan-domain`
+  - `--scan-signal`
 - append at least one structured event:
-  - `pnpm workflow-memory:add-entry --workflow "Periodic Scans" ...`
+  - `pnpm workflow-memory:add-entry --workflow "Periodic Scans" --tags best-practice-researcher,... --scan-walk-mode weighted-random --scan-scope <macro|meso|micro> --scan-domain <domain> --scan-signal <1-5> ...`
 - commit and push memory append artifacts after each run:
   - `pnpm workflow-memory:sync --message "chore(workflow-memory): best-practice-researcher run memory"`
 - if `workflow-memory:sync` reports non-fast-forward, allow it to auto-rebase

--- a/agent-engine/scripts/__tests__/workflow-memory-scan-metadata.test.ts
+++ b/agent-engine/scripts/__tests__/workflow-memory-scan-metadata.test.ts
@@ -1,0 +1,223 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, '..', '..', '..');
+const addEntryScriptPath = path.join(currentDir, "..", "workflow-memory", "add-entry.ts");
+const retrieveScriptPath = path.join(currentDir, "..", "workflow-memory", "retrieve.ts");
+const tsxBinaryPath = path.join(repoRoot, "node_modules", ".bin", "tsx");
+
+const tempDirs: string[] = [];
+
+async function createWorkflowMemoryFixture(indexRows: unknown[] = []): Promise<string> {
+  const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "workflow-memory-scan-"));
+  tempDirs.push(fixtureDir);
+
+  const memoryRoot = path.join(fixtureDir, "agent-engine", "workflow-memory");
+  await mkdir(path.join(memoryRoot, "events"), { recursive: true });
+  await writeFile(path.join(memoryRoot, "index.json"), `${JSON.stringify(indexRows, null, 2)}\n`, "utf8");
+
+  return fixtureDir;
+}
+
+function runWorkflowMemoryScript(scriptPath: string, args: string[], cwd: string) {
+  return spawnSync(tsxBinaryPath, [scriptPath, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) =>
+      rm(dir, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+describe("workflow-memory structured scan metadata", () => {
+  it("writes scan metadata to events and index rows", async () => {
+    const fixtureDir = await createWorkflowMemoryFixture();
+    const result = runWorkflowMemoryScript(
+      addEntryScriptPath,
+      [
+        "--id",
+        "scan-metadata-entry",
+        "--date",
+        "2026-02-23",
+        "--workflow",
+        "Periodic Scans",
+        "--title",
+        "best-practice-researcher: scan entry",
+        "--trigger",
+        "test",
+        "--finding",
+        "structured metadata check",
+        "--evidence",
+        "tests",
+        "--follow-up",
+        "none",
+        "--owner",
+        "@automation",
+        "--status",
+        "open",
+        "--tags",
+        "best-practice-researcher,periodic-scans",
+        "--scan-walk-mode",
+        "weighted-random",
+        "--scan-scope",
+        "meso",
+        "--scan-domain",
+        "api-contracts-orpc-hono",
+        "--scan-signal",
+        "4",
+      ],
+      fixtureDir,
+    );
+
+    expect(result.status).toBe(0);
+
+    const eventsPath = path.join(
+      fixtureDir,
+      "agent-engine",
+      "workflow-memory",
+      "events",
+      "2026-02.jsonl",
+    );
+    const eventLines = (await readFile(eventsPath, "utf8")).trim().split(/\r?\n/);
+    const event = JSON.parse(eventLines[0]) as { scan?: Record<string, unknown> };
+    expect(event.scan).toEqual({
+      walkMode: "weighted-random",
+      scope: "meso",
+      domain: "api-contracts-orpc-hono",
+      signal: "4",
+    });
+
+    const indexPath = path.join(fixtureDir, "agent-engine", "workflow-memory", "index.json");
+    const indexRows = JSON.parse(await readFile(indexPath, "utf8")) as Array<{
+      scan?: Record<string, unknown>;
+    }>;
+    expect(indexRows[0]?.scan).toEqual({
+      walkMode: "weighted-random",
+      scope: "meso",
+      domain: "api-contracts-orpc-hono",
+      signal: "4",
+    });
+  }, 20_000);
+
+  it("rejects best-practice Periodic Scans entries that omit scan metadata", async () => {
+    const fixtureDir = await createWorkflowMemoryFixture();
+    const result = runWorkflowMemoryScript(
+      addEntryScriptPath,
+      [
+        "--id",
+        "scan-metadata-missing",
+        "--date",
+        "2026-02-23",
+        "--workflow",
+        "Periodic Scans",
+        "--title",
+        "best-practice-researcher: missing metadata",
+        "--trigger",
+        "test",
+        "--finding",
+        "missing structured metadata",
+        "--evidence",
+        "tests",
+        "--follow-up",
+        "none",
+        "--owner",
+        "@automation",
+        "--status",
+        "open",
+        "--tags",
+        "best-practice-researcher,periodic-scans",
+      ],
+      fixtureDir,
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      'must include structured scan metadata via --scan-walk-mode, --scan-scope, --scan-domain, and --scan-signal',
+    );
+  }, 20_000);
+
+  it("filters retrieve results by scan scope/domain and reports scan metadata", async () => {
+    const fixtureDir = await createWorkflowMemoryFixture([
+      {
+        id: "scan-target",
+        date: "2026-02-23",
+        month: "2026-02",
+        workflow: "Periodic Scans",
+        title: "target row",
+        severity: "medium",
+        status: "open",
+        tags: ["best-practice-researcher"],
+        scan: {
+          walkMode: "weighted-random",
+          scope: "meso",
+          domain: "api-contracts-orpc-hono",
+          signal: "4",
+        },
+        eventFile: "events/2026-02.jsonl",
+      },
+      {
+        id: "scan-other",
+        date: "2026-02-22",
+        month: "2026-02",
+        workflow: "Periodic Scans",
+        title: "other row",
+        severity: "medium",
+        status: "open",
+        tags: ["best-practice-researcher"],
+        scan: {
+          walkMode: "weighted-random",
+          scope: "macro",
+          domain: "docs-and-guardrail-drift",
+          signal: "3",
+        },
+        eventFile: "events/2026-02.jsonl",
+      },
+    ]);
+
+    const result = runWorkflowMemoryScript(
+      retrieveScriptPath,
+      [
+        "--workflow",
+        "Periodic Scans",
+        "--scan-scope",
+        "meso",
+        "--scan-domain",
+        "api-contracts-orpc-hono",
+        "--limit",
+        "10",
+        "--min-score",
+        "0",
+      ],
+      fixtureDir,
+    );
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as {
+      query: { scanScope: string | null; scanDomain: string | null };
+      results: Array<{ id: string; scan?: Record<string, unknown> }>;
+    };
+
+    expect(parsed.query.scanScope).toBe("meso");
+    expect(parsed.query.scanDomain).toBe("api-contracts-orpc-hono");
+    expect(parsed.results.map((row) => row.id)).toEqual(["scan-target"]);
+    expect(parsed.results[0]?.scan).toEqual({
+      walkMode: "weighted-random",
+      scope: "meso",
+      domain: "api-contracts-orpc-hono",
+      signal: "4",
+    });
+  }, 20_000);
+});

--- a/agent-engine/scripts/workflow-memory/add-entry.ts
+++ b/agent-engine/scripts/workflow-memory/add-entry.ts
@@ -27,6 +27,8 @@ const MEMORY_FUNCTION_PREFIX = "memory-function:";
 const MEMORY_DYNAMICS_PREFIX = "memory-dynamics:";
 const CAPABILITY_PREFIX = "capability:";
 const FAILURE_PREFIX = "failure:";
+const PERIODIC_SCANS_WORKFLOW = "Periodic Scans";
+const BEST_PRACTICE_RESEARCHER_TAG = "best-practice-researcher";
 
 const MEMORY_FORM_VALUES = new Set(["parametric", "external"]);
 const MEMORY_FUNCTION_VALUES = new Set(["semantic", "episodic", "working"]);
@@ -75,7 +77,11 @@ const USAGE = `Usage:
     [--scenario-check <check-name>] \\
     [--scenario-verdict pass|fail] \\
     [--scenario-pattern <pattern-name>] \\
-    [--scenario-severity low|medium|high|critical]
+    [--scenario-severity low|medium|high|critical] \\
+    [--scan-walk-mode <mode>] \\
+    [--scan-scope <scope>] \\
+    [--scan-domain <domain>] \\
+    [--scan-signal <signal>]
 
 Scenario flags:
   When any --scenario-* flag is provided, --scenario-skill and --scenario-verdict
@@ -343,6 +349,44 @@ function buildScenario(args) {
   };
 }
 
+function parseScanValue(raw, flagName) {
+  if (raw === undefined) {
+    return "";
+  }
+
+  const normalized = String(raw).trim().toLowerCase();
+  if (!normalized) {
+    throw new Error(`Invalid ${flagName}: expected a non-empty value.`);
+  }
+
+  return normalized;
+}
+
+function buildScanMetadata(args) {
+  const walkMode = parseScanValue(args.scan_walk_mode, "--scan-walk-mode");
+  const scope = parseScanValue(args.scan_scope, "--scan-scope");
+  const domain = parseScanValue(args.scan_domain, "--scan-domain");
+  const signal = parseScanValue(args.scan_signal, "--scan-signal");
+
+  const provided = [walkMode, scope, domain, signal].filter(Boolean);
+  if (provided.length === 0) {
+    return undefined;
+  }
+
+  if (provided.length !== 4) {
+    throw new Error(
+      "Structured scan metadata requires all scan flags together: --scan-walk-mode, --scan-scope, --scan-domain, --scan-signal.",
+    );
+  }
+
+  return {
+    walkMode,
+    scope,
+    domain,
+    signal,
+  };
+}
+
 function buildEvent(args) {
   const date = args.date ?? new Date().toISOString().slice(0, 10);
   if (!validateDate(date)) {
@@ -410,6 +454,17 @@ function buildEvent(args) {
   };
 
   const scenario = buildScenario(args);
+  const scan = buildScanMetadata(args);
+
+  if (
+    workflow === PERIODIC_SCANS_WORKFLOW &&
+    tags.includes(BEST_PRACTICE_RESEARCHER_TAG) &&
+    !scan
+  ) {
+    throw new Error(
+      `Periodic Scans entries tagged "${BEST_PRACTICE_RESEARCHER_TAG}" must include structured scan metadata via --scan-walk-mode, --scan-scope, --scan-domain, and --scan-signal.`,
+    );
+  }
 
   return {
     id,
@@ -428,6 +483,7 @@ function buildEvent(args) {
     tags,
     ...scoring,
     ...(scenario ? { scenario } : {}),
+    ...(scan ? { scan } : {}),
     source: (args.source ?? "manual").trim(),
     createdAt: new Date().toISOString(),
   };
@@ -472,6 +528,7 @@ async function main() {
     ...(typeof event.recency === "number" ? { recency: event.recency } : {}),
     ...(typeof event.confidence === "number" ? { confidence: event.confidence } : {}),
     ...(event.scenario ? { hasScenario: true, scenarioSkill: event.scenario.skill } : {}),
+    ...(event.scan ? { scan: event.scan } : {}),
     eventFile: path.join("events", `${month}.jsonl`),
   };
 

--- a/agent-engine/scripts/workflow-memory/retrieve.ts
+++ b/agent-engine/scripts/workflow-memory/retrieve.ts
@@ -15,7 +15,9 @@ const USAGE = `Usage:
     --min-score 0.35 \\
     [--month YYYY-MM] \\
     [--has-scenario] \\
-    [--scenario-skill <skill-name>]
+    [--scenario-skill <skill-name>] \\
+    [--scan-scope <scope>] \\
+    [--scan-domain <domain>]
 
 Scoring (0-1):
   score = 0.4 * importance + 0.3 * recency + 0.2 * tagMatch + 0.1 * confidence
@@ -106,6 +108,25 @@ function parseMinScore(raw) {
   throw new Error(`Invalid --min-score value: ${raw}`);
 }
 
+function parseFilterValue(raw, flagName) {
+  if (raw === undefined || raw === null) return "";
+  const normalized = String(raw).trim().toLowerCase();
+  if (!normalized) {
+    throw new Error(`Invalid ${flagName} value: expected a non-empty string.`);
+  }
+  return normalized;
+}
+
+function readScanField(row, key) {
+  if (!row || typeof row !== "object") return null;
+  const scan = row.scan;
+  if (!scan || typeof scan !== "object") return null;
+  const value = scan[key];
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized || null;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
 
@@ -130,6 +151,8 @@ async function main() {
 
   const hasScenario = args.has_scenario === "true";
   const scenarioSkill = args.scenario_skill ? args.scenario_skill.trim() : "";
+  const scanScope = parseFilterValue(args.scan_scope, "--scan-scope");
+  const scanDomain = parseFilterValue(args.scan_domain, "--scan-domain");
 
   const scored = index
     .filter((row) => {
@@ -138,9 +161,18 @@ async function main() {
       if (month && row.month !== month) return false;
       if (hasScenario && !row.hasScenario) return false;
       if (scenarioSkill && row.scenarioSkill !== scenarioSkill) return false;
+      if (scanScope && readScanField(row, "scope") !== scanScope) return false;
+      if (scanDomain && readScanField(row, "domain") !== scanDomain) return false;
       return true;
     })
     .map((row) => {
+      const scan = {
+        walkMode: readScanField(row, "walkMode"),
+        scope: readScanField(row, "scope"),
+        domain: readScanField(row, "domain"),
+        signal: readScanField(row, "signal"),
+      };
+      const hasScanMetadata = scan.walkMode || scan.scope || scan.domain || scan.signal;
       const importance = clamp01(parseOptionalNumber(row.importance) ?? 0);
       const confidence = clamp01(parseOptionalNumber(row.confidence) ?? 0);
       const recency = clamp01(
@@ -163,6 +195,7 @@ async function main() {
           tagMatch,
           confidence,
         },
+        ...(hasScanMetadata ? { scan } : {}),
         eventFile: row.eventFile,
       };
     })
@@ -177,6 +210,8 @@ async function main() {
       month: month || null,
       minScore,
       limit,
+      scanScope: scanScope || null,
+      scanDomain: scanDomain || null,
     },
     results: scored,
   };

--- a/agent-engine/workflow-memory/README.md
+++ b/agent-engine/workflow-memory/README.md
@@ -84,6 +84,15 @@ standards.
   - `importance` (0-1, higher = more critical or reusable)
   - `recency` (0-1, higher = more recent; override computed recency if needed)
   - `confidence` (0-1, higher = more reliable evidence)
+  - `scan` (optional object for structured random-walk metadata):
+    - `walkMode`
+    - `scope`
+    - `domain`
+    - `signal`
+
+For `workflow: "Periodic Scans"` entries tagged `best-practice-researcher`, `scan`
+metadata is required and must be provided through
+`--scan-walk-mode`, `--scan-scope`, `--scan-domain`, and `--scan-signal`.
 
 ## Index (Fast Retrieval)
 
@@ -102,6 +111,7 @@ Each index row contains:
 - `importance` (optional 0-1)
 - `recency` (optional 0-1)
 - `confidence` (optional 0-1)
+- `scan` (optional object mirroring event `scan` metadata)
 - `eventFile`
 
 ## Summaries (Human Compression)
@@ -187,6 +197,26 @@ pnpm workflow-memory:add-entry \
 This appends an event to the current month and updates `index.json`.
 It also regenerates `summaries/YYYY-MM.md` for the event month.
 
+Periodic scan events can be logged with explicit random-walk metadata:
+
+```bash
+pnpm workflow-memory:add-entry \
+  --workflow "Periodic Scans" \
+  --title "best-practice-researcher: meso scan (api-contracts-orpc-hono)" \
+  --trigger "Scheduled random-walk run" \
+  --finding "Opened issue #123 after protocol contract drift check" \
+  --evidence "https://github.com/<org>/<repo>/issues/123" \
+  --follow-up "Await issue-evaluator label decision" \
+  --owner "@automation" \
+  --status "open" \
+  --severity "medium" \
+  --tags best-practice-researcher,periodic-scans \
+  --scan-walk-mode weighted-random \
+  --scan-scope meso \
+  --scan-domain api-contracts-orpc-hono \
+  --scan-signal 4
+```
+
 For automation runs, persist the append to git immediately:
 
 ```bash
@@ -241,6 +271,12 @@ Sample output (truncated):
         "docs",
         "workflow-memory"
       ],
+      "scan": {
+        "walkMode": "weighted-random",
+        "scope": "meso",
+        "domain": "api-contracts-orpc-hono",
+        "signal": "4"
+      },
       "score": 0.86,
       "breakdown": {
         "importance": 0.8,
@@ -252,6 +288,17 @@ Sample output (truncated):
     }
   ]
 }
+```
+
+Filter retrieval by structured random-walk metadata:
+
+```bash
+pnpm workflow-memory:retrieve \
+  --workflow "Periodic Scans" \
+  --scan-scope meso \
+  --scan-domain api-contracts-orpc-hono \
+  --limit 8 \
+  --min-score 0
 ```
 
 ## Coverage Audit


### PR DESCRIPTION
## Summary
- add structured `scan` metadata support to `workflow-memory:add-entry` and index rows (`walkMode`, `scope`, `domain`, `signal`)
- require scan metadata for `Periodic Scans` events tagged `best-practice-researcher` to prevent free-text-only random-walk logging
- extend `workflow-memory:retrieve` with `--scan-scope`/`--scan-domain` filters and include scan metadata in retrieval results
- add script-level regression tests and update workflow-memory + best-practice playbook documentation/examples

## Aggregated Issues
- Fixes #18 (fully resolved)

## Workflow Routing
- #18 -> **Self-Improvement**
  - Skills used: `self-improvement`, `intake-triage`, `test-surface-steward`
  - Rationale: this is a process/guardrail hardening change for automation memory schema, retrieval behavior, and recurrence prevention tests.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

Fixes #18
