### PR TITLE
feat(api): inject SSE publisher Effect service for runs

### DIFF
--- a/packages/api/src/server/runtime.ts
+++ b/packages/api/src/server/runtime.ts
@@ -7,6 +7,10 @@ import { ManagedRuntime, Layer, Logger } from 'effect';
 import type { StorageConfig } from './orpc';
 import type { DatabaseInstance } from '@repo/db/client';
 import type { Storage } from '@repo/storage';
+import {
+  SSEPublisherLive,
+  type SSEPublisher,
+} from './sse-publisher-service';
 import { createStorageLayer } from './storage-factory';
 
 /**
@@ -21,7 +25,8 @@ export type SharedServices =
   | Policy
   | Storage
   | Queue
-  | AI;
+  | AI
+  | SSEPublisher;
 
 /**
  * Configuration for creating the server runtime.
@@ -53,6 +58,7 @@ export const createSharedLayers = (
   const policyLayer = DatabasePolicyLive.pipe(Layer.provide(dbLayer));
   const queueLayer = QueueLive.pipe(Layer.provide(dbLayer));
   const storageLayer = createStorageLayer(config.storageConfig);
+  const ssePublisherLayer = SSEPublisherLive;
 
   const aiLayer: Layer.Layer<AI> = config.useMockAI
     ? MockAIWithLatency
@@ -66,6 +72,7 @@ export const createSharedLayers = (
     queueLayer,
     storageLayer,
     aiLayer,
+    ssePublisherLayer,
     loggerLayer,
   );
 };

--- a/packages/api/src/server/sse-publisher-service.ts
+++ b/packages/api/src/server/sse-publisher-service.ts
@@ -1,0 +1,22 @@
+import { Context, Effect, Layer } from 'effect';
+import type { SSEEvent } from '../contracts/events';
+import { ssePublisher } from './publisher';
+
+export interface SSEPublisherService {
+  readonly publish: (
+    userId: string,
+    event: SSEEvent,
+  ) => Effect.Effect<void, never>;
+}
+
+export class SSEPublisher extends Context.Tag('@repo/api/SSEPublisher')<
+  SSEPublisher,
+  SSEPublisherService
+>() {}
+
+export const SSEPublisherLive = Layer.succeed(SSEPublisher, {
+  publish: (userId, event) =>
+    Effect.sync(() => {
+      ssePublisher.publish(userId, event);
+    }),
+});

--- a/packages/api/src/server/use-cases/__tests__/runs.test.ts
+++ b/packages/api/src/server/use-cases/__tests__/runs.test.ts
@@ -10,7 +10,10 @@ import {
 import { Effect, Layer } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { User } from '@repo/auth/policy';
-import { ssePublisher } from '../../publisher';
+import {
+  SSEPublisher,
+  type SSEPublisherService,
+} from '../../sse-publisher-service';
 import { createRunUseCase, listRunsUseCase } from '../runs';
 
 const TEST_USER: User = {
@@ -39,6 +42,13 @@ const createMockQueueService = (
   ...overrides,
 });
 
+const createMockPublisherService = (
+  overrides: Partial<SSEPublisherService> = {},
+): SSEPublisherService => ({
+  publish: () => Effect.succeed(undefined),
+  ...overrides,
+});
+
 const createJob = (overrides: Partial<RunJob> = {}): RunJob => ({
   id: 'job_test' as RunJob['id'],
   type: QueueJobType.PROCESS_AI_RUN,
@@ -58,7 +68,16 @@ const createJob = (overrides: Partial<RunJob> = {}): RunJob => ({
   ...overrides,
 });
 
-const withQueue = (queue: QueueService) => Effect.provide(Layer.succeed(Queue, queue));
+const withQueueAndPublisher = (
+  queue: QueueService,
+  publisher: SSEPublisherService = createMockPublisherService(),
+) =>
+  Effect.provide(
+    Layer.mergeAll(
+      Layer.succeed(Queue, queue),
+      Layer.succeed(SSEPublisher, publisher),
+    ),
+  );
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -81,9 +100,10 @@ describe('runs use-cases', () => {
       }) as QueueService['enqueue'],
     });
 
-    const publishSpy = vi
-      .spyOn(ssePublisher, 'publish')
-      .mockImplementation(() => undefined);
+    const publish = vi.fn<SSEPublisherService['publish']>(() =>
+      Effect.succeed(undefined),
+    );
+    const publisher = createMockPublisherService({ publish });
 
     const result = await Effect.runPromise(
       createRunUseCase({
@@ -92,7 +112,7 @@ describe('runs use-cases', () => {
           prompt: 'Plan quarterly roadmap',
           threadId: 'thread_123',
         },
-      }).pipe(withQueue(queue)),
+      }).pipe(withQueueAndPublisher(queue, publisher)),
     );
 
     expect(enqueueType).toBe(QueueJobType.PROCESS_AI_RUN);
@@ -102,7 +122,16 @@ describe('runs use-cases', () => {
       threadId: 'thread_123',
       userId: TEST_USER.id,
     });
-    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(
+      TEST_USER.id,
+      expect.objectContaining({
+        type: 'run_queued',
+        runId: 'job_test',
+        prompt: 'Plan quarterly roadmap',
+        threadId: 'thread_123',
+      }),
+    );
     expect(result.prompt).toBe('Plan quarterly roadmap');
     expect(result.threadId).toBe('thread_123');
   });
@@ -120,7 +149,7 @@ describe('runs use-cases', () => {
           input: {
             prompt: 'Plan quarterly roadmap',
           },
-        }).pipe(withQueue(queue)),
+        }).pipe(withQueueAndPublisher(queue)),
       ),
     );
 
@@ -156,7 +185,7 @@ describe('runs use-cases', () => {
       listRunsUseCase({
         user: TEST_USER,
         input: { limit: 1 },
-      }).pipe(withQueue(queue)),
+      }).pipe(withQueueAndPublisher(queue)),
     );
 
     expect(listUserId).toBe(TEST_USER.id);
@@ -188,7 +217,7 @@ describe('runs use-cases', () => {
       listRunsUseCase({
         user: TEST_USER,
         input: {},
-      }).pipe(withQueue(queue)),
+      }).pipe(withQueueAndPublisher(queue)),
     );
 
     expect(runs).toHaveLength(1);
@@ -207,7 +236,7 @@ describe('runs use-cases', () => {
         listRunsUseCase({
           user: TEST_USER,
           input: {},
-        }).pipe(withQueue(queue)),
+        }).pipe(withQueueAndPublisher(queue)),
       ),
     );
 

--- a/packages/api/src/server/use-cases/runs.ts
+++ b/packages/api/src/server/use-cases/runs.ts
@@ -12,7 +12,7 @@ import {
   type RunOutput,
   type RunResult,
 } from '../../contracts/runs';
-import { ssePublisher } from '../publisher';
+import { SSEPublisher } from '../sse-publisher-service';
 
 type RunJob = TypedJob<typeof QueueJobType.PROCESS_AI_RUN>;
 
@@ -129,6 +129,7 @@ const toRunOutput = (
 export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
   Effect.gen(function* () {
     const queue = yield* Queue;
+    const publisher = yield* SSEPublisher;
 
     const created = yield* queue.enqueue(
       QueueJobType.PROCESS_AI_RUN,
@@ -145,15 +146,13 @@ export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
       CREATE_RUN_SOURCE_PATH,
     );
 
-    yield* Effect.sync(() =>
-      ssePublisher.publish(user.id, {
-        type: 'run_queued',
-        runId: run.id,
-        prompt: run.prompt,
-        threadId: run.threadId,
-        timestamp: new Date().toISOString(),
-      }),
-    );
+    yield* publisher.publish(user.id, {
+      type: 'run_queued',
+      runId: run.id,
+      prompt: run.prompt,
+      threadId: run.threadId,
+      timestamp: new Date().toISOString(),
+    });
 
     return run;
   });


### PR DESCRIPTION
## Summary
- inject an Effect-tagged `SSEPublisher` service for run event publishing
- wire `SSEPublisherLive` into the shared server runtime layer graph
- refactor `createRunUseCase` to use injected publisher dependency instead of direct singleton import
- update runs use-case tests to provide a mock publisher layer and assert emitted event payload

Fixes #21

## Aggregated Issues
- #21 — Fixes #21 (fully resolved)

## Workflow Routing
- #21: `Architecture + ADR Guard` (skills: `architecture-adr-guard`, `intake-triage`, `test-surface-steward`)

## Research Log Update
- Not applicable: issue #21 did not include a Research Trace section or external paper link.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`
