### PR TITLE
fix: align Claude safety gate guardrails and invariant checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,14 @@ pnpm lint
 pnpm test
 pnpm test:invariants
 pnpm build
+pnpm scripts:lint
+```
+
+## After Skill Changes
+
+```bash
+agent-engine/scripts/sync-skills.sh
+pnpm skills:check:strict
 ```
 
 ## Non-Negotiables

--- a/docs/testing/invariants.md
+++ b/docs/testing/invariants.md
@@ -74,6 +74,7 @@ Required for all agent-authored backend changes.
 | Rule | What It Prevents |
 |---|---|
 | All `pnpm test:invariants` files must appear in this doc | Invariant-doc drift and missing documentation |
+| `AGENTS.md` and `CLAUDE.md` must both include required safety commands (`pnpm scripts:lint`, skill sync, and strict skill checks) | Instruction-surface drift where one agent path can bypass script/skill guardrails |
 
 ## When to Update Invariants
 <!-- enforced-by: manual-review -->

--- a/packages/testing/src/__tests__/docs-invariants.test.ts
+++ b/packages/testing/src/__tests__/docs-invariants.test.ts
@@ -8,6 +8,14 @@ const repoRoot = path.resolve(currentDir, '..', '..', '..', '..');
 
 const packageJsonPath = path.join(repoRoot, 'package.json');
 const docsPath = path.join(repoRoot, 'docs/testing/invariants.md');
+const agentsInstructionsPath = path.join(repoRoot, 'AGENTS.md');
+const claudeInstructionsPath = path.join(repoRoot, 'CLAUDE.md');
+
+const REQUIRED_SAFETY_COMMANDS = [
+  'pnpm scripts:lint',
+  'agent-engine/scripts/sync-skills.sh',
+  'pnpm skills:check:strict',
+] as const;
 
 const extractInvariantFiles = (script: string): string[] => {
   const tokens = script.split(/\s+/).filter(Boolean);
@@ -40,6 +48,27 @@ describe('invariant docs sync', () => {
     expect(
       missing,
       'Invariant docs must list every test:invariants file path.',
+    ).toEqual([]);
+  });
+
+  it('keeps AGENTS and CLAUDE safety-command contracts aligned', () => {
+    const agents = fs.readFileSync(agentsInstructionsPath, 'utf-8');
+    const claude = fs.readFileSync(claudeInstructionsPath, 'utf-8');
+
+    const missingInAgents = REQUIRED_SAFETY_COMMANDS.filter(
+      (command) => !agents.includes(command),
+    );
+    const missingInClaude = REQUIRED_SAFETY_COMMANDS.filter(
+      (command) => !claude.includes(command),
+    );
+
+    expect(
+      missingInAgents,
+      'AGENTS.md must include all required safety commands.',
+    ).toEqual([]);
+    expect(
+      missingInClaude,
+      'CLAUDE.md must include all required safety commands.',
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #24

## Summary
- Added `pnpm scripts:lint` to `CLAUDE.md` quality gates.
- Added a post-skill-change section to `CLAUDE.md` with `agent-engine/scripts/sync-skills.sh` and `pnpm skills:check:strict`.
- Extended `packages/testing/src/__tests__/docs-invariants.test.ts` to enforce AGENTS/CLAUDE required safety-command parity.
- Updated `docs/testing/invariants.md` to document the new invariant rule.

## Aggregated Issues
- Fixes #24 (fully resolved in this PR)

## Workflow Routing
- #24 -> Self-Improvement
- Skills used: self-improvement, intake-triage, test-surface-steward
- Route rationale: this issue hardens instruction and invariant guardrails to prevent recurring process drift.

## Research Log Update
- Not applicable: issue #24 has no Research Trace or external paper references.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`
