### PR TITLE
fix(api): preserve auth context failures and add enduser span attrs

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -9,8 +9,8 @@
 ## Required Attributes
 
 - `request.id` for API spans
+- `enduser.id` for authenticated API spans
 - `queue.job.id` for queue transitions
-- user identifier when available
 
 ## Error Logging
 

--- a/packages/api/src/server/__tests__/effect-handler.span-attributes.test.ts
+++ b/packages/api/src/server/__tests__/effect-handler.span-attributes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '@repo/auth/policy';
+import {
+  buildHandlerSpanAttributes,
+  ENDUSER_ID_SPAN_ATTRIBUTE,
+} from '../effect-handler';
+
+const TEST_USER: User = {
+  id: 'user_1',
+  email: 'user@example.com',
+  name: 'Example User',
+  role: 'user',
+};
+
+describe('buildHandlerSpanAttributes', () => {
+  it('adds request.id and enduser.id for authenticated requests', () => {
+    const attributes = buildHandlerSpanAttributes({
+      attributes: { 'api.route': 'runs.list' },
+      requestId: 'req-auth',
+      user: TEST_USER,
+    });
+
+    expect(attributes).toEqual({
+      'api.route': 'runs.list',
+      'request.id': 'req-auth',
+      [ENDUSER_ID_SPAN_ATTRIBUTE]: TEST_USER.id,
+    });
+  });
+
+  it('omits enduser.id for unauthenticated requests', () => {
+    const attributes = buildHandlerSpanAttributes({
+      requestId: 'req-public',
+      user: null,
+    });
+
+    expect(attributes).toEqual({
+      'request.id': 'req-public',
+    });
+    expect(attributes).not.toHaveProperty(ENDUSER_ID_SPAN_ATTRIBUTE);
+  });
+
+  it('preserves custom attributes when request and user are absent', () => {
+    const attributes = buildHandlerSpanAttributes({
+      attributes: { 'run.limit': 20 },
+      user: null,
+    });
+
+    expect(attributes).toEqual({
+      'run.limit': 20,
+    });
+  });
+});

--- a/packages/api/src/server/__tests__/orpc.context.behavior.test.ts
+++ b/packages/api/src/server/__tests__/orpc.context.behavior.test.ts
@@ -1,0 +1,99 @@
+import { PolicyError } from '@repo/auth';
+import { Effect } from 'effect';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ServerRuntime } from '../runtime';
+import type { AuthInstance } from '@repo/auth/server';
+import { createORPCContext } from '../orpc';
+
+const getSessionWithRoleMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@repo/auth/server', async () => {
+  const actual = await vi.importActual('@repo/auth/server');
+
+  return {
+    ...actual,
+    getSessionWithRole: getSessionWithRoleMock,
+  };
+});
+
+const testRuntime = {
+  runPromise: <A, E>(effect: Effect.Effect<A, E, never>) =>
+    Effect.runPromise(effect),
+} as unknown as ServerRuntime;
+
+describe('createORPCContext', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getSessionWithRoleMock.mockReset();
+  });
+
+  it('returns null session and user for unauthenticated requests', async () => {
+    getSessionWithRoleMock.mockReturnValueOnce(Effect.succeed(null));
+
+    const context = await createORPCContext({
+      auth: {} as AuthInstance,
+      runtime: testRuntime,
+      headers: new Headers(),
+      requestId: 'req-unauthenticated',
+    });
+
+    expect(context.session).toBeNull();
+    expect(context.user).toBeNull();
+    expect(context.requestId).toBe('req-unauthenticated');
+  });
+
+  it('returns session and user for authenticated requests', async () => {
+    const authResult = {
+      session: {
+        id: 'session_1',
+        userId: 'user_1',
+        expiresAt: new Date('2026-02-23T00:00:00.000Z'),
+        createdAt: new Date('2026-02-23T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-23T00:00:00.000Z'),
+        token: 'token_1',
+      },
+      user: {
+        id: 'user_1',
+        email: 'user@example.com',
+        name: 'Example User',
+        role: 'user' as const,
+      },
+    };
+    getSessionWithRoleMock.mockReturnValueOnce(Effect.succeed(authResult));
+
+    const context = await createORPCContext({
+      auth: {} as AuthInstance,
+      runtime: testRuntime,
+      headers: new Headers(),
+      requestId: 'req-authenticated',
+    });
+
+    expect(context.session).toEqual(authResult.session);
+    expect(context.user).toEqual(authResult.user);
+    expect(context.requestId).toBe('req-authenticated');
+  });
+
+  it('rethrows policy failures and logs request correlation + failure class', async () => {
+    const policyError = new PolicyError({
+      message: 'role lookup failed',
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    getSessionWithRoleMock.mockReturnValueOnce(Effect.fail(policyError));
+
+    await expect(
+      createORPCContext({
+        auth: {} as AuthInstance,
+        runtime: testRuntime,
+        headers: new Headers(),
+        requestId: 'req-policy-failure',
+      }),
+    ).rejects.toThrow('role lookup failed');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[AUTH_CONTEXT][requestId:req-policy-failure][failure:PolicyError]',
+      ),
+      policyError,
+    );
+  });
+});

--- a/packages/api/src/server/effect-handler.ts
+++ b/packages/api/src/server/effect-handler.ts
@@ -18,6 +18,22 @@ export interface HandleEffectOptions {
   requestId?: string;
 }
 
+export const ENDUSER_ID_SPAN_ATTRIBUTE = 'enduser.id' as const;
+
+export const buildHandlerSpanAttributes = ({
+  attributes,
+  requestId,
+  user,
+}: {
+  attributes?: Record<string, string | number | boolean>;
+  requestId?: string;
+  user: User | null;
+}): Record<string, string | number | boolean> => ({
+  ...(attributes ?? {}),
+  ...(requestId ? { 'request.id': requestId } : {}),
+  ...(user ? { [ENDUSER_ID_SPAN_ATTRIBUTE]: user.id } : {}),
+});
+
 /**
  * Error factory function signature.
  * Compatible with oRPC's ORPCErrorConstructorMapItem which uses rest params
@@ -263,10 +279,11 @@ export const handleEffectWithProtocol = <A, E extends { _tag: string }>(
 ): Promise<A> => {
   const tracedEffect = effect.pipe(
     Effect.withSpan(options.span, {
-      attributes: {
-        ...options.attributes,
-        ...(options.requestId ? { 'request.id': options.requestId } : {}),
-      },
+      attributes: buildHandlerSpanAttributes({
+        attributes: options.attributes,
+        requestId: options.requestId,
+        user,
+      }),
     }),
   );
 

--- a/packages/api/src/server/orpc.ts
+++ b/packages/api/src/server/orpc.ts
@@ -44,6 +44,18 @@ export interface AuthenticatedORPCContext extends ORPCContext {
   user: User;
 }
 
+const getAuthContextFailureClass = (error: unknown): string => {
+  if (error && typeof error === 'object' && '_tag' in error) {
+    return String((error as { _tag: unknown })._tag);
+  }
+
+  if (error instanceof Error) {
+    return error.name;
+  }
+
+  return typeof error;
+};
+
 /**
  * Creates the oRPC context for a request.
  *
@@ -67,13 +79,12 @@ export const createORPCContext = async ({
 }): Promise<ORPCContext> => {
   const result = await runtime.runPromise(
     getSessionWithRole(auth, headers).pipe(
-      Effect.catchAll((error) =>
+      Effect.tapError((error) =>
         Effect.sync(() => {
-          console.warn(
-            '[AUTH_CONTEXT] Session lookup failed:',
-            error instanceof Error ? error.message : String(error),
+          console.error(
+            `[AUTH_CONTEXT][requestId:${requestId}][failure:${getAuthContextFailureClass(error)}] Context bootstrap failed`,
+            error,
           );
-          return null;
         }),
       ),
     ),


### PR DESCRIPTION
## Summary
- preserve PolicyError/dependency failures during oRPC context bootstrap instead of coercing failures to unauthenticated `null`
- add correlated auth-context failure logging that includes both `requestId` and failure class
- add canonical `enduser.id` API span attribute for authenticated requests and keep public spans free of user id
- update observability docs and add focused behavior tests for both context bootstrap and span-attribute behavior

## Aggregated Issues
- Fixes #26 (primary): preserve policy/dependency failure semantics in oRPC context bootstrap
- Fixes #31: add canonical API end-user span attribute in centralized handler flow

## Workflow Routing
- #26: `Feature Delivery` using skill `feature-delivery`
- #31: `Feature Delivery` using skill `feature-delivery`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Not applicable for this bundle (no Research Trace / external paper links requiring `research/implemented-ideas.md` update).
