### PR TITLE
fix(queue): align processNextJob contract with persisted failures

### DIFF
--- a/docs/patterns/job-queue.md
+++ b/docs/patterns/job-queue.md
@@ -12,5 +12,7 @@
 
 - Claim atomically with `FOR UPDATE SKIP LOCKED`.
 - Write terminal status on any failure path.
+- `processNextJob` persists handler failures as `FAILED` jobs and returns the
+  updated job row instead of surfacing handler failures in its error channel.
 - Reap stale `processing` jobs on poll cadence and log checked/affected counts.
 - Record timestamps for start/completion.

--- a/packages/queue/src/__tests__/service.test.ts
+++ b/packages/queue/src/__tests__/service.test.ts
@@ -1,6 +1,21 @@
 import { Effect, Layer } from 'effect';
 import { describe, it, expect } from 'vitest';
+import type { JobProcessingError } from '../errors';
 import { Queue, type QueueService } from '../service';
+
+type ProcessNextJobError = Effect.Effect.Error<
+  ReturnType<QueueService['processNextJob']>
+>;
+
+const assertNoProcessingErrorLeak = <
+  T extends Extract<ProcessNextJobError, JobProcessingError> extends never
+    ? true
+    : false,
+>(
+  value: T,
+) => value;
+
+assertNoProcessingErrorLeak(true);
 
 describe('Queue service', () => {
   it('has the correct tag identifier', () => {

--- a/packages/queue/src/repository.ts
+++ b/packages/queue/src/repository.ts
@@ -264,7 +264,7 @@ const makeQueueService = Effect.gen(function* () {
     ) => Effect.Effect<unknown, JobProcessingError, R>,
   ): Effect.Effect<
     TypedJob<TType> | null,
-    QueueError | JobProcessingError | JobNotFoundError,
+    QueueError | JobNotFoundError,
     R
   > =>
     claimNextJob(type).pipe(

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -39,6 +39,10 @@ export interface QueueService {
     error?: string,
   ) => Effect.Effect<Job, QueueError | JobNotFoundError>;
 
+  /**
+   * Claims one pending job and runs the handler.
+   * Handler failures are persisted as FAILED job status and returned as updated rows.
+   */
   readonly processNextJob: <TType extends JobType, R = never>(
     type: TType,
     handler: (
@@ -46,7 +50,7 @@ export interface QueueService {
     ) => Effect.Effect<unknown, JobProcessingError, R>,
   ) => Effect.Effect<
     TypedJob<TType> | null,
-    QueueError | JobProcessingError | JobNotFoundError,
+    QueueError | JobNotFoundError,
     R
   >;
 


### PR DESCRIPTION
## Summary
- align `QueueService.processNextJob` error-channel typing with actual persisted-failure behavior by removing `JobProcessingError` from its returned error union
- update queue repository implementation signature to match the service contract without changing runtime behavior
- add a compile-time regression guard in queue service tests to fail if `JobProcessingError` reappears in `processNextJob`'s error channel
- document the canonical persisted-failure contract in `docs/patterns/job-queue.md`

Fixes #35

## Aggregated Issues
- Fixes #35 (fully resolved)

## Workflow Routing
- #35 -> Feature Delivery (`feature-delivery`) with companion skills: `intake-triage`, `debug-fix`, `test-surface-steward`
  Rationale: scoped queue-domain implementation and regression-proofing, no architecture-boundary deviation requiring ADR workflow.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`
