### PR TITLE
feat(api): enforce chat input schema and OpenAPI request body coverage

### DIFF
--- a/agent-engine/scripts/spec/generate-openapi.ts
+++ b/agent-engine/scripts/spec/generate-openapi.ts
@@ -1,5 +1,6 @@
 import { appContract } from '../../../packages/api/src/contracts/index.ts';
 import path from 'node:path';
+import { JSONSchema, Schema } from 'effect';
 import { generatedRoot, stableSortObject, writeUtf8 } from './utils';
 
 type ContractOperation = {
@@ -10,6 +11,7 @@ type ContractOperation = {
   readonly summary: string;
   readonly description: string;
   readonly streaming: boolean;
+  readonly inputSchema?: unknown;
 };
 
 type OpenApiOperation = {
@@ -17,6 +19,14 @@ type OpenApiOperation = {
   readonly tags?: readonly string[];
   readonly summary?: string;
   readonly description?: string;
+  readonly requestBody?: {
+    required: boolean;
+    content: {
+      'application/json': {
+        schema: Record<string, unknown>;
+      };
+    };
+  };
   readonly responses: Record<string, unknown>;
 };
 
@@ -36,6 +46,8 @@ const asRecord = (value: unknown): Record<string, unknown> | null => {
   }
   return value as Record<string, unknown>;
 };
+
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
 
 const csvCell = (value: string): string => value.replaceAll('|', '\\|');
 
@@ -83,6 +95,7 @@ const collectContractOperations = (
         description:
           typeof route.description === 'string' ? route.description : '',
         streaming: isStreamingOutput(meta?.outputSchema),
+        inputSchema: meta?.inputSchema,
       });
     }
   }
@@ -95,6 +108,33 @@ const collectContractOperations = (
   }
 
   return operations;
+};
+
+const toRequestBody = (
+  method: string,
+  inputSchema: unknown,
+): OpenApiOperation['requestBody'] | undefined => {
+  if (!BODY_METHODS.has(method)) {
+    return undefined;
+  }
+
+  if (!Schema.isSchema(inputSchema)) {
+    return undefined;
+  }
+
+  try {
+    const schema = stableSortObject(JSONSchema.make(inputSchema));
+    return {
+      required: true,
+      content: {
+        'application/json': {
+          schema,
+        },
+      },
+    };
+  } catch {
+    return undefined;
+  }
 };
 
 const toOpenApiOperation = (operation: ContractOperation): OpenApiOperation => {
@@ -115,6 +155,7 @@ const toOpenApiOperation = (operation: ContractOperation): OpenApiOperation => {
     tags: operation.tags.length > 0 ? operation.tags : undefined,
     summary: operation.summary || undefined,
     description: operation.description || undefined,
+    requestBody: toRequestBody(operation.method, operation.inputSchema),
     responses: {
       '200': {
         description: 'Successful response',
@@ -145,7 +186,7 @@ const buildOpenApiDocument = (
       title: 'Agent Engine Template API (Spec Snapshot)',
       version: '1.0.0',
       description:
-        'Generated from oRPC contract metadata. Request/response schemas are intentionally omitted in this initial snapshot.',
+        'Generated from oRPC contract metadata. Request schemas are included when Effect Standard Schemas are available.',
     },
     servers: [{ url: '/api' }],
     paths,

--- a/docs/spec/generated/openapi.json
+++ b/docs/spec/generated/openapi.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "description": "Generated from oRPC contract metadata. Request/response schemas are intentionally omitted in this initial snapshot.",
+    "description": "Generated from oRPC contract metadata. Request schemas are included when Effect Standard Schemas are available.",
     "title": "Agent Engine Template API (Spec Snapshot)",
     "version": "1.0.0"
   },
@@ -9,6 +9,88 @@
     "/chat/general": {
       "post": {
         "operationId": "chat.general",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "messages": {
+                    "description": "an array of at most 100 item(s)",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "id": {
+                          "description": "a string at most 128 character(s) long",
+                          "maxLength": 128,
+                          "minLength": 1,
+                          "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                          "title": "maxLength(128)",
+                          "type": "string"
+                        },
+                        "parts": {
+                          "description": "an array of at most 64 item(s)",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "text": {
+                                "description": "a string at most 8000 character(s) long",
+                                "maxLength": 8000,
+                                "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                                "title": "maxLength(8000)",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "a string at most 64 character(s) long",
+                                "maxLength": 64,
+                                "minLength": 1,
+                                "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                                "title": "maxLength(64)",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object"
+                          },
+                          "maxItems": 64,
+                          "minItems": 1,
+                          "title": "maxItems(64)",
+                          "type": "array"
+                        },
+                        "role": {
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "role",
+                        "parts"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 100,
+                    "minItems": 1,
+                    "title": "maxItems(100)",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "messages"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
@@ -63,6 +145,38 @@
       "post": {
         "description": "Queue a background AI run and track progress via SSE.",
         "operationId": "runs.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "prompt": {
+                    "description": "a string at most 4000 character(s) long",
+                    "maxLength": 4000,
+                    "minLength": 1,
+                    "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                    "title": "maxLength(4000)",
+                    "type": "string"
+                  },
+                  "threadId": {
+                    "description": "a string at most 128 character(s) long",
+                    "maxLength": 128,
+                    "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                    "title": "maxLength(128)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Successful response"

--- a/docs/testing/invariants.md
+++ b/docs/testing/invariants.md
@@ -24,6 +24,16 @@ Required for all agent-authored backend changes.
 | Chat routes avoid direct `runtime.runPromise` | Bypassing shared handler pipeline |
 | Chat handlers define `api.chat.*` spans | Missing or inconsistent tracing |
 
+### API Chat Contract Invariants
+<!-- enforced-by: invariant-test -->
+
+**File:** `packages/api/src/contracts/__tests__/chat-contract.invariants.test.ts`
+
+| Rule | What It Prevents |
+|---|---|
+| `chat.general` input must remain Standard Schema-backed with bounded message validation | Regressing to trust-only inputs or unbounded payload shapes |
+| Generated OpenAPI for `/chat/general` must include a request body schema | API docs drift that hides required chat input payloads |
+
 ### API Router Handler Invariants
 <!-- enforced-by: invariant-test -->
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start": "turbo run start",
     "test": "vitest run",
     "test:scripts": "vitest run --config agent-engine/scripts/vitest.config.ts",
-    "test:invariants": "vitest run packages/api/src/server/__tests__/effect-handler.invariants.test.ts packages/api/src/server/__tests__/error-assertions.invariants.test.ts packages/api/src/server/__tests__/chat-handler.invariants.test.ts packages/api/src/server/__tests__/router-handler.invariants.test.ts packages/testing/src/__tests__/docs-invariants.test.ts",
+    "test:invariants": "vitest run packages/api/src/server/__tests__/effect-handler.invariants.test.ts packages/api/src/server/__tests__/error-assertions.invariants.test.ts packages/api/src/server/__tests__/chat-handler.invariants.test.ts packages/api/src/server/__tests__/router-handler.invariants.test.ts packages/api/src/contracts/__tests__/chat-contract.invariants.test.ts packages/testing/src/__tests__/docs-invariants.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:coverage:api": "pnpm --filter @repo/api test:coverage",

--- a/packages/api/src/contracts/__tests__/chat-contract.invariants.test.ts
+++ b/packages/api/src/contracts/__tests__/chat-contract.invariants.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveContractProcedures } from '@orpc/server';
+import { describe, expect, it } from 'vitest';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { appContract } from '../index';
+
+type ChatGeneralOperation = {
+  requestBody?: {
+    content?: Record<string, { schema?: unknown }>;
+  };
+};
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, '..', '..', '..', '..', '..');
+const openApiSnapshotPath = path.join(repoRoot, 'docs/spec/generated/openapi.json');
+
+const getChatInputSchema = async (): Promise<StandardSchemaV1> => {
+  let schema: StandardSchemaV1 | undefined;
+
+  await resolveContractProcedures(
+    { path: [], router: appContract },
+    ({ contract, path }) => {
+      if (path.join('.') === 'chat.general') {
+        const def = contract['~orpc'];
+        schema = def.inputSchema as StandardSchemaV1 | undefined;
+      }
+    },
+  );
+
+  if (!schema) {
+    throw new Error('chat.general input schema is missing from contract');
+  }
+
+  return schema;
+};
+
+const validate = async (
+  schema: StandardSchemaV1,
+  value: unknown,
+): Promise<StandardSchemaV1.Result<unknown>> =>
+  Promise.resolve(schema['~standard'].validate(value));
+
+describe('chat contract invariants', () => {
+  it('enforces bounded schema validation for chat messages input', async () => {
+    const schema = await getChatInputSchema();
+
+    const validInput = {
+      messages: [
+        {
+          id: 'msg_1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello there' }],
+        },
+      ],
+    };
+
+    const valid = await validate(schema, validInput);
+    expect(valid.issues).toBeUndefined();
+
+    const emptyMessages = await validate(schema, { messages: [] });
+    expect(emptyMessages.issues).toBeDefined();
+
+    const invalidRole = await validate(schema, {
+      messages: [{ id: 'msg_1', role: 'tool', parts: [{ type: 'text' }] }],
+    });
+    expect(invalidRole.issues).toBeDefined();
+
+    const oversizedPayload = await validate(schema, {
+      messages: Array.from({ length: 101 }, (_, index) => ({
+        id: `msg_${index}`,
+        role: 'user',
+        parts: [{ type: 'text', text: 'x' }],
+      })),
+    });
+    expect(oversizedPayload.issues).toBeDefined();
+
+    const oversizedTextPart = await validate(schema, {
+      messages: [
+        {
+          id: 'msg_1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'x'.repeat(8_001) }],
+        },
+      ],
+    });
+    expect(oversizedTextPart.issues).toBeDefined();
+  });
+
+  it('keeps chat request body coverage in generated OpenAPI snapshot', () => {
+    const openApiDocument = JSON.parse(
+      fs.readFileSync(openApiSnapshotPath, 'utf-8'),
+    ) as {
+      paths?: Record<string, { post?: ChatGeneralOperation }>;
+    };
+
+    const operation = openApiDocument.paths?.['/chat/general']?.post;
+    const requestBodySchema =
+      operation?.requestBody?.content?.['application/json']?.schema;
+
+    expect(requestBodySchema).toBeDefined();
+  });
+});

--- a/packages/api/src/contracts/chat.ts
+++ b/packages/api/src/contracts/chat.ts
@@ -1,7 +1,42 @@
 import { oc, eventIterator, type } from '@orpc/contract';
-import type { UIMessage, UIMessageChunk } from 'ai';
+import { Schema } from 'effect';
+import type { UIMessageChunk } from 'ai';
+import { std } from './shared';
 
-const ChatMessagesInput = type<{ messages: UIMessage[] }>();
+const ChatMessageRoleSchema = Schema.Literal('system', 'user', 'assistant');
+
+const ChatMessagePartSchema = Schema.Struct({
+  type: Schema.String.pipe(
+    Schema.trimmed(),
+    Schema.minLength(1),
+    Schema.maxLength(64),
+  ),
+  text: Schema.optional(
+    Schema.String.pipe(Schema.trimmed(), Schema.maxLength(8_000)),
+  ),
+});
+
+const ChatMessageSchema = Schema.Struct({
+  id: Schema.String.pipe(
+    Schema.trimmed(),
+    Schema.minLength(1),
+    Schema.maxLength(128),
+  ),
+  role: ChatMessageRoleSchema,
+  parts: Schema.Array(ChatMessagePartSchema).pipe(
+    Schema.minItems(1),
+    Schema.maxItems(64),
+  ),
+});
+
+const ChatMessagesInputSchema = Schema.Struct({
+  messages: Schema.Array(ChatMessageSchema).pipe(
+    Schema.minItems(1),
+    Schema.maxItems(100),
+  ),
+});
+
+const ChatMessagesInput = std(ChatMessagesInputSchema);
 const ChatStreamOutput = eventIterator(type<UIMessageChunk>());
 
 const chatContract = oc

--- a/packages/api/src/server/router/chat.ts
+++ b/packages/api/src/server/router/chat.ts
@@ -1,4 +1,5 @@
 import { streamGeneralChat } from '@repo/ai/chat';
+import type { UIMessage } from 'ai';
 import {
   handleEffectStreamWithProtocol,
 } from '../effect-handler';
@@ -10,7 +11,9 @@ const chatRouter = {
       handleEffectStreamWithProtocol(
         context.runtime,
         context.user,
-        streamGeneralChat({ messages: input.messages }),
+        streamGeneralChat({
+          messages: input.messages as unknown as UIMessage[],
+        }),
         errors,
         { requestId: context.requestId, span: 'api.chat.general' },
       ),


### PR DESCRIPTION
## Summary
- replace the chat contract `type` utility input with a bounded Standard Schema for message payload validation
- add a contract invariant test to lock chat input validation behavior and require `/chat/general` requestBody presence in generated OpenAPI
- extend OpenAPI generation to emit request bodies from Effect-backed input schemas for body methods, and regenerate `docs/spec/generated/openapi.json`
- document the new invariant and wire it into `pnpm test:invariants`

Fixes #27

## Aggregated Issues
- Fixes #27 (full resolution)

## Workflow Routing
- #27: `Feature Delivery` via `feature-delivery` with utility skills `intake-triage` and `test-surface-steward`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`
