### PR TITLE
feat(api): enforce OpenAPI error-response parity for protected routes

### DIFF
--- a/agent-engine/scripts/spec/generate-openapi.ts
+++ b/agent-engine/scripts/spec/generate-openapi.ts
@@ -12,6 +12,13 @@ type ContractOperation = {
   readonly description: string;
   readonly streaming: boolean;
   readonly inputSchema?: unknown;
+  readonly errorResponses: readonly ContractErrorResponse[];
+};
+
+type ContractErrorResponse = {
+  readonly code: string;
+  readonly status: number;
+  readonly message?: string;
 };
 
 type OpenApiOperation = {
@@ -49,7 +56,31 @@ const asRecord = (value: unknown): Record<string, unknown> | null => {
 
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
 
+const ORPC_ERROR_STATUS_FALLBACKS: Readonly<Record<string, number>> = {
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  METHOD_NOT_SUPPORTED: 405,
+  NOT_ACCEPTABLE: 406,
+  TIMEOUT: 408,
+  CONFLICT: 409,
+  PAYLOAD_TOO_LARGE: 413,
+  UNSUPPORTED_MEDIA_TYPE: 415,
+  UNPROCESSABLE_CONTENT: 422,
+  TOO_MANY_REQUESTS: 429,
+  CLIENT_CLOSED_REQUEST: 499,
+  INTERNAL_SERVER_ERROR: 500,
+  NOT_IMPLEMENTED: 501,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+  GATEWAY_TIMEOUT: 504,
+};
+
 const csvCell = (value: string): string => value.replaceAll('|', '\\|');
+
+const fallbackErrorStatus = (code: string): number =>
+  ORPC_ERROR_STATUS_FALLBACKS[code] ?? 500;
 
 const isStreamingOutput = (outputSchema: unknown): boolean => {
   const schemaRecord = asRecord(outputSchema);
@@ -61,6 +92,39 @@ const isStreamingOutput = (outputSchema: unknown): boolean => {
   return Object.getOwnPropertySymbols(standard).some((symbol) =>
     String(symbol).includes('EVENT_ITERATOR'),
   );
+};
+
+const collectErrorResponses = (
+  errorMap: unknown,
+): readonly ContractErrorResponse[] => {
+  const errorMapRecord = asRecord(errorMap);
+  if (!errorMapRecord) return [];
+
+  const responses: ContractErrorResponse[] = [];
+
+  for (const [code, config] of Object.entries(errorMapRecord)) {
+    const configRecord = asRecord(config);
+    const configuredStatus =
+      typeof configRecord?.status === 'number' &&
+      Number.isInteger(configRecord.status)
+        ? configRecord.status
+        : undefined;
+    const status = configuredStatus ?? fallbackErrorStatus(code);
+
+    // Error responses should only contribute non-2xx statuses.
+    if (status >= 200 && status < 300) continue;
+
+    responses.push({
+      code,
+      status,
+      message:
+        typeof configRecord?.message === 'string'
+          ? configRecord.message
+          : undefined,
+    });
+  }
+
+  return responses;
 };
 
 const collectContractOperations = (
@@ -96,6 +160,7 @@ const collectContractOperations = (
           typeof route.description === 'string' ? route.description : '',
         streaming: isStreamingOutput(meta?.outputSchema),
         inputSchema: meta?.inputSchema,
+        errorResponses: collectErrorResponses(meta?.errorMap),
       });
     }
   }
@@ -137,6 +202,47 @@ const toRequestBody = (
   }
 };
 
+const buildErrorResponses = (
+  errorResponses: readonly ContractErrorResponse[],
+): Record<string, unknown> => {
+  const grouped = new Map<number, { codes: string[]; messages: string[] }>();
+
+  for (const errorResponse of errorResponses) {
+    const existing = grouped.get(errorResponse.status);
+    if (existing) {
+      existing.codes.push(errorResponse.code);
+      if (errorResponse.message) {
+        existing.messages.push(errorResponse.message);
+      }
+      continue;
+    }
+
+    grouped.set(errorResponse.status, {
+      codes: [errorResponse.code],
+      messages: errorResponse.message ? [errorResponse.message] : [],
+    });
+  }
+
+  const sortedEntries = [...grouped.entries()].sort((a, b) => a[0] - b[0]);
+  const responses: Record<string, unknown> = {};
+
+  for (const [status, aggregate] of sortedEntries) {
+    const codes = [...new Set(aggregate.codes)];
+    const messages = [...new Set(aggregate.messages)];
+
+    const description =
+      messages.length === 1
+        ? messages[0]
+        : codes.length === 1
+          ? `${codes[0]} error response`
+          : `Error responses: ${codes.join(', ')}`;
+
+    responses[String(status)] = { description };
+  }
+
+  return responses;
+};
+
 const toOpenApiOperation = (operation: ContractOperation): OpenApiOperation => {
   const responseContent = operation.streaming
     ? {
@@ -150,6 +256,8 @@ const toOpenApiOperation = (operation: ContractOperation): OpenApiOperation => {
       }
     : {};
 
+  const errorResponses = buildErrorResponses(operation.errorResponses);
+
   return {
     operationId: operation.operationId,
     tags: operation.tags.length > 0 ? operation.tags : undefined,
@@ -161,6 +269,7 @@ const toOpenApiOperation = (operation: ContractOperation): OpenApiOperation => {
         description: 'Successful response',
         ...responseContent,
       },
+      ...errorResponses,
     },
   };
 };

--- a/docs/spec/generated/openapi.json
+++ b/docs/spec/generated/openapi.json
@@ -101,6 +101,27 @@
               }
             },
             "description": "Successful response"
+          },
+          "401": {
+            "description": "Missing user session. Please log in!"
+          },
+          "403": {
+            "description": "You do not have enough permission to perform this action."
+          },
+          "404": {
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "description": "INPUT_VALIDATION_FAILED error response"
+          },
+          "429": {
+            "description": "Too many requests. Please try again later."
+          },
+          "500": {
+            "description": "An internal error occurred. Please try again later."
+          },
+          "502": {
+            "description": "An external service is currently unavailable."
           }
         },
         "tags": [
@@ -121,6 +142,27 @@
               }
             },
             "description": "Successful response"
+          },
+          "401": {
+            "description": "Missing user session. Please log in!"
+          },
+          "403": {
+            "description": "You do not have enough permission to perform this action."
+          },
+          "404": {
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "description": "INPUT_VALIDATION_FAILED error response"
+          },
+          "429": {
+            "description": "Too many requests. Please try again later."
+          },
+          "500": {
+            "description": "An internal error occurred. Please try again later."
+          },
+          "502": {
+            "description": "An external service is currently unavailable."
           }
         },
         "tags": [
@@ -135,6 +177,27 @@
         "responses": {
           "200": {
             "description": "Successful response"
+          },
+          "401": {
+            "description": "Missing user session. Please log in!"
+          },
+          "403": {
+            "description": "You do not have enough permission to perform this action."
+          },
+          "404": {
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "description": "INPUT_VALIDATION_FAILED error response"
+          },
+          "429": {
+            "description": "Too many requests. Please try again later."
+          },
+          "500": {
+            "description": "An internal error occurred. Please try again later."
+          },
+          "502": {
+            "description": "An external service is currently unavailable."
           }
         },
         "summary": "List runs",
@@ -180,6 +243,27 @@
         "responses": {
           "200": {
             "description": "Successful response"
+          },
+          "401": {
+            "description": "Missing user session. Please log in!"
+          },
+          "403": {
+            "description": "You do not have enough permission to perform this action."
+          },
+          "404": {
+            "description": "The requested resource was not found."
+          },
+          "422": {
+            "description": "INPUT_VALIDATION_FAILED error response"
+          },
+          "429": {
+            "description": "Too many requests. Please try again later."
+          },
+          "500": {
+            "description": "An internal error occurred. Please try again later."
+          },
+          "502": {
+            "description": "An external service is currently unavailable."
           }
         },
         "summary": "Create run",

--- a/packages/api/src/contracts/__tests__/openapi-compatibility.test.ts
+++ b/packages/api/src/contracts/__tests__/openapi-compatibility.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getEventIteratorSchemaDetails } from '@orpc/contract';
 import { resolveContractProcedures } from '@orpc/server';
 import * as Schema from 'effect/Schema';
@@ -18,7 +21,29 @@ type CompatibilityException = {
   reason: string;
 };
 
+type ProtectedOpenApiParityException = {
+  operationId: string;
+  status: number;
+  reason: string;
+};
+
+type OpenApiOperation = {
+  operationId?: unknown;
+  responses?: Record<string, unknown>;
+};
+
+type OpenApiDocument = {
+  paths?: Record<string, Record<string, OpenApiOperation>>;
+};
+
+type OperationMetadata = {
+  path: string;
+  method: string;
+  responses: Record<string, unknown>;
+};
+
 const openApiCompatibilityExceptions: CompatibilityException[] = [];
+const protectedOpenApiParityExceptions: ProtectedOpenApiParityException[] = [];
 
 const exceptionReasons = new Map(
   openApiCompatibilityExceptions.map((exception) => [
@@ -27,11 +52,128 @@ const exceptionReasons = new Map(
   ]),
 );
 
+const ORPC_ERROR_STATUS_FALLBACKS: Readonly<Record<string, number>> = {
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  METHOD_NOT_SUPPORTED: 405,
+  NOT_ACCEPTABLE: 406,
+  TIMEOUT: 408,
+  CONFLICT: 409,
+  PAYLOAD_TOO_LARGE: 413,
+  UNSUPPORTED_MEDIA_TYPE: 415,
+  UNPROCESSABLE_CONTENT: 422,
+  TOO_MANY_REQUESTS: 429,
+  CLIENT_CLOSED_REQUEST: 499,
+  INTERNAL_SERVER_ERROR: 500,
+  NOT_IMPLEMENTED: 501,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+  GATEWAY_TIMEOUT: 504,
+};
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, '..', '..', '..', '..', '..');
+const openApiSnapshotPath = path.join(repoRoot, 'docs/spec/generated/openapi.json');
+const routerDir = path.join(repoRoot, 'packages/api/src/server/router');
+
 const buildExceptionKey = (
   path: string,
   location: string,
   kind: string,
 ): string => `${path}::${location}::${kind}`;
+
+const buildParityExceptionKey = (
+  operationId: string,
+  status: number,
+): string => `${operationId}::${status}`;
+
+const parityExceptionReasons = new Map(
+  protectedOpenApiParityExceptions.map((exception) => [
+    buildParityExceptionKey(exception.operationId, exception.status),
+    exception.reason,
+  ]),
+);
+
+const fallbackErrorStatus = (code: string): number =>
+  ORPC_ERROR_STATUS_FALLBACKS[code] ?? 500;
+
+const collectExpectedErrorStatuses = (
+  errorMap: Record<string, unknown>,
+): readonly number[] => {
+  const statuses = new Set<number>();
+
+  for (const [code, config] of Object.entries(errorMap)) {
+    const configRecord =
+      typeof config === 'object' && config !== null
+        ? (config as Record<string, unknown>)
+        : {};
+    const configuredStatus =
+      typeof configRecord.status === 'number' &&
+      Number.isInteger(configRecord.status)
+        ? configRecord.status
+        : undefined;
+    const status = configuredStatus ?? fallbackErrorStatus(code);
+
+    if (status >= 200 && status < 300) continue;
+    statuses.add(status);
+  }
+
+  return [...statuses].sort((a, b) => a - b);
+};
+
+const collectProtectedOperationIds = (): Set<string> => {
+  const protectedOperationIds = new Set<string>();
+  const routerFiles = fs
+    .readdirSync(routerDir)
+    .filter((file) => file.endsWith('.ts'))
+    .filter((file) => file !== 'index.ts')
+    .sort();
+
+  const protectedProcedurePattern =
+    /protectedProcedure\.([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)\.handler/g;
+
+  for (const file of routerFiles) {
+    const source = fs.readFileSync(path.join(routerDir, file), 'utf-8');
+    let match: RegExpExecArray | null = null;
+
+    while ((match = protectedProcedurePattern.exec(source)) !== null) {
+      const namespace = match[1];
+      const procedure = match[2];
+      if (!namespace || !procedure) continue;
+      protectedOperationIds.add(`${namespace}.${procedure}`);
+    }
+  }
+
+  return protectedOperationIds;
+};
+
+const readOpenApiOperations = (): Map<string, OperationMetadata> => {
+  const document = JSON.parse(
+    fs.readFileSync(openApiSnapshotPath, 'utf-8'),
+  ) as OpenApiDocument;
+  const operations = new Map<string, OperationMetadata>();
+
+  for (const [httpPath, pathItem] of Object.entries(document.paths ?? {})) {
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (!operation || typeof operation !== 'object') continue;
+      const operationId =
+        typeof operation.operationId === 'string'
+          ? operation.operationId
+          : undefined;
+      if (!operationId) continue;
+
+      operations.set(operationId, {
+        path: httpPath,
+        method,
+        responses: operation.responses ?? {},
+      });
+    }
+  }
+
+  return operations;
+};
 
 const collectSchemaIssues = (
   schema: unknown,
@@ -174,5 +316,83 @@ describe('OpenAPI compatibility guard', () => {
     }
 
     expect(actionable).toEqual([]);
+  });
+
+  it('keeps protected route error-response parity with contract error maps', async () => {
+    const protectedOperationIds = collectProtectedOperationIds();
+    const openApiOperations = readOpenApiOperations();
+    const parityIssues: string[] = [];
+    const usedExceptions = new Set<string>();
+
+    await resolveContractProcedures(
+      { path: [], router: appContract },
+      ({ contract, path }) => {
+        const operationId = path.join('.');
+        if (!protectedOperationIds.has(operationId)) {
+          return;
+        }
+
+        const def = contract['~orpc'];
+        const expectedStatuses = collectExpectedErrorStatuses(def.errorMap);
+        const openApiOperation = openApiOperations.get(operationId);
+
+        if (!openApiOperation) {
+          parityIssues.push(
+            `- ${operationId}: missing operation in OpenAPI snapshot`,
+          );
+          return;
+        }
+
+        const responseStatuses = new Set(Object.keys(openApiOperation.responses));
+
+        for (const status of expectedStatuses) {
+          const statusKey = String(status);
+          if (responseStatuses.has(statusKey)) {
+            continue;
+          }
+
+          const exceptionKey = buildParityExceptionKey(operationId, status);
+          const exceptionReason = parityExceptionReasons.get(exceptionKey);
+          if (exceptionReason) {
+            usedExceptions.add(exceptionKey);
+            continue;
+          }
+
+          parityIssues.push(
+            `- ${operationId} (${openApiOperation.method.toUpperCase()} ${openApiOperation.path}): missing error status ${statusKey}`,
+          );
+        }
+      },
+    );
+
+    const staleExceptions = protectedOpenApiParityExceptions.filter(
+      (exception) =>
+        !usedExceptions.has(
+          buildParityExceptionKey(exception.operationId, exception.status),
+        ),
+    );
+
+    if (staleExceptions.length > 0) {
+      parityIssues.push(
+        ...staleExceptions.map(
+          (exception) =>
+            `- stale exception ${exception.operationId}::${exception.status} (${exception.reason})`,
+        ),
+      );
+    }
+
+    if (parityIssues.length > 0) {
+      throw new Error(
+        [
+          'OpenAPI error-response parity guard failed for protected routes.',
+          '',
+          ...parityIssues,
+          '',
+          'If a missing status is a known tooling limitation, add a documented entry to protectedOpenApiParityExceptions in this test.',
+        ].join('\n'),
+      );
+    }
+
+    expect(parityIssues).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add error-response extraction to OpenAPI snapshot generation so contract error maps materialize in generated operation responses
- extend OpenAPI compatibility guard with protected-route parity assertions between contract error statuses and generated OpenAPI responses
- regenerate `docs/spec/generated/openapi.json` with non-2xx error response coverage for protected API operations

Fixes #28

## Aggregated Issues
- Fixes #28 (full)

## Workflow Routing
- #28 -> `Feature Delivery` workflow using skills: `feature-delivery`, `test-surface-steward`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Not applicable (issue references docs links, no Research Trace or external paper link to record).
