### PR TITLE
fix(api): handle Effect defect causes in protocol helper

### DIFF
--- a/packages/api/src/server/__tests__/effect-handler.behavior.test.ts
+++ b/packages/api/src/server/__tests__/effect-handler.behavior.test.ts
@@ -1,0 +1,157 @@
+import { Effect, Layer, ManagedRuntime } from 'effect';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ServerRuntime } from '../runtime';
+import {
+  handleEffectWithProtocol,
+  type ErrorFactory,
+  type HandleEffectOptions,
+} from '../effect-handler';
+
+interface FactoryOptions {
+  message: string;
+  data?: unknown;
+}
+
+interface ProtocolErrorPayload {
+  code: string;
+  status: number;
+  message: string;
+  data?: unknown;
+}
+
+type SerializedFiberFailure = {
+  cause?: {
+    _tag?: string;
+    defect?: ProtocolErrorPayload;
+  };
+};
+
+const createFactory =
+  (code: string, status: number) =>
+  (options: FactoryOptions): ProtocolErrorPayload => ({
+    code,
+    status,
+    message: options.message,
+    data: options.data,
+  });
+
+const createErrors = (): ErrorFactory & {
+  CONFLICT: (options: FactoryOptions) => ProtocolErrorPayload;
+  INTERNAL_ERROR: (options: FactoryOptions) => ProtocolErrorPayload;
+  NOT_FOUND: (options: FactoryOptions) => ProtocolErrorPayload;
+} => ({
+  CONFLICT: createFactory('CONFLICT', 409),
+  INTERNAL_ERROR: createFactory('INTERNAL_ERROR', 500),
+  NOT_FOUND: createFactory('NOT_FOUND', 404),
+});
+
+const createRuntime = (): ServerRuntime =>
+  ManagedRuntime.make(Layer.empty) as unknown as ServerRuntime;
+
+const extractDieDefect = (error: unknown): ProtocolErrorPayload | null => {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  const serialized = JSON.parse(JSON.stringify(error)) as SerializedFiberFailure;
+  if (serialized.cause?._tag !== 'Die') {
+    return null;
+  }
+
+  return serialized.cause.defect ?? null;
+};
+
+class TaggedConflictError extends Error {
+  readonly _tag = 'TaggedConflictError';
+  static readonly httpStatus = 409;
+  static readonly httpCode = 'CONFLICT';
+  static readonly httpMessage = 'Tagged conflict';
+  static readonly logLevel = 'silent' as const;
+}
+
+const createOptions = (requestId: string): HandleEffectOptions => ({
+  span: 'api.tests.effect-handler',
+  requestId,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('handleEffectWithProtocol', () => {
+  it('maps tagged failures with protocol metadata', async () => {
+    const thrown = await handleEffectWithProtocol(
+      createRuntime(),
+      null,
+      Effect.fail(new TaggedConflictError()),
+      createErrors(),
+      createOptions('req-tagged'),
+    ).catch((error) => error);
+
+    const defect = extractDieDefect(thrown);
+    expect(defect).not.toBeNull();
+    expect(defect).toMatchObject({
+      code: 'CONFLICT',
+      status: 409,
+      message: 'Tagged conflict',
+    });
+  });
+
+  it('preserves custom tagged-error override behavior', async () => {
+    const errors = createErrors();
+    let receivedTag: string | null = null;
+
+    const thrown = await handleEffectWithProtocol(
+      createRuntime(),
+      null,
+      Effect.fail(new TaggedConflictError()),
+      errors,
+      createOptions('req-custom'),
+      {
+        TaggedConflictError: (error: unknown): never => {
+          if (error instanceof TaggedConflictError) {
+            receivedTag = error._tag;
+          }
+          throw errors.NOT_FOUND({ message: 'custom override' });
+        },
+      },
+    ).catch((error) => error);
+
+    const defect = extractDieDefect(thrown);
+    expect(receivedTag).toBe('TaggedConflictError');
+    expect(defect).not.toBeNull();
+    expect(defect).toMatchObject({
+      code: 'NOT_FOUND',
+      status: 404,
+      message: 'custom override',
+    });
+  });
+
+  it('maps defects to INTERNAL_ERROR and logs request correlation/failure class', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const thrown = await handleEffectWithProtocol(
+      createRuntime(),
+      null,
+      Effect.die(new Error('boom')),
+      createErrors(),
+      createOptions('req-defect'),
+    ).catch((error) => error);
+
+    const defect = extractDieDefect(thrown);
+    expect(defect).not.toBeNull();
+    expect(defect).toMatchObject({
+      code: 'INTERNAL_ERROR',
+      status: 500,
+      message: 'An unexpected error occurred',
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[effect-handler] Falling back to INTERNAL_ERROR',
+      expect.objectContaining({
+        'request.id': 'req-defect',
+        failureClass: 'defect',
+      }),
+    );
+  });
+});

--- a/packages/api/src/server/effect-handler.ts
+++ b/packages/api/src/server/effect-handler.ts
@@ -3,7 +3,7 @@ import { ValidationError } from '@orpc/contract';
 import { streamToEventIterator } from '@orpc/server';
 import { withCurrentUser, type User } from '@repo/auth/policy';
 import { hasHttpProtocol, type LogLevel } from '@repo/db/error-protocol';
-import { Effect, Match, pipe } from 'effect';
+import { Cause, Effect, Match, Option, pipe } from 'effect';
 import type { ServerRuntime, SharedServices } from './runtime';
 
 /**
@@ -163,6 +163,33 @@ const logError = (
   }
 };
 
+type FailureClass = 'typed-failure' | 'defect' | 'interrupt' | 'unknown';
+
+const classifyFailureClass = <E>(cause: Cause.Cause<E>): FailureClass => {
+  if (Cause.isInterruptedOnly(cause)) {
+    return 'interrupt';
+  }
+  if (Cause.isDie(cause)) {
+    return 'defect';
+  }
+  if (Cause.isFailure(cause)) {
+    return 'typed-failure';
+  }
+  return 'unknown';
+};
+
+const logUnexpectedCauseFallback = <E>(
+  cause: Cause.Cause<E>,
+  requestId?: string,
+): void => {
+  const failureClass = classifyFailureClass(cause);
+  console.error('[effect-handler] Falling back to INTERNAL_ERROR', {
+    'request.id': requestId ?? null,
+    failureClass,
+    cause: Cause.pretty(cause, { renderErrorCause: true }),
+  });
+};
+
 /**
  * Generic error handler that reads HTTP protocol from error class.
  * Works with any error that implements HttpErrorProtocol via static properties.
@@ -293,16 +320,24 @@ export const handleEffectWithProtocol = <A, E extends { _tag: string }>(
 
   return runtime.runPromise(
     scopedEffect.pipe(
-      Effect.catchAll((error: E) =>
+      Effect.catchAllCause((cause) =>
         Effect.sync(() => {
-          // Check for custom handler first
-          const customHandler = customHandlers?.[error._tag];
-          if (customHandler) {
-            return customHandler(error);
+          const failureOption = Cause.failureOption(cause);
+          if (Option.isSome(failureOption)) {
+            const error = failureOption.value;
+
+            // Check for custom handler first
+            const customHandler = customHandlers?.[error._tag];
+            if (customHandler) {
+              return customHandler(error);
+            }
+
+            // Use generic protocol-based handler
+            return handleTaggedError(error, errors, options.requestId);
           }
 
-          // Use generic protocol-based handler
-          return handleTaggedError(error, errors, options.requestId);
+          logUnexpectedCauseFallback(cause, options.requestId);
+          return throwInternalError(errors, 'An unexpected error occurred');
         }),
       ),
     ),


### PR DESCRIPTION
## Summary
- handle both typed failures and non-typed Effect causes in handleEffectWithProtocol using catchAllCause
- preserve custom tagged-error override behavior for typed failures
- map defect/non-typed causes to stable INTERNAL_ERROR protocol fallback with request-correlated logging (request.id, failureClass)
- add behavior tests for tagged mapping, custom override, and defect fallback mapping

Fixes #33

## Aggregated Issues
- Fixes #33 — fully resolved

## Workflow Routing
- #33 -> **Feature Delivery** + intake-triage + test-surface-steward
  Rationale: backend API-boundary behavior fix with explicit regression-test coverage and no architecture-boundary change.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build

## Research Log Update
- Not required for this issue: references are Effect documentation links (no research trace/external paper links).
