### PR TITLE
feat(ai): standardize prompt registry + versioned resolver

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Template scope:
 ## Directory Layout
 
 - `docs/architecture/` - boundaries, security, telemetry
+- `docs/architecture/prompt-registry.md` - prompt artifact/versioning and resolver policy
 - `docs/patterns/` - backend implementation patterns
 - `docs/frontend/` - web app architecture and conventions
 - `docs/testing/` - testing expectations by change type

--- a/docs/architecture/prompt-registry.md
+++ b/docs/architecture/prompt-registry.md
@@ -1,0 +1,77 @@
+# Prompt Registry and Versioning
+
+## Scope
+
+Prompt artifacts are first-class, git-versioned assets in `packages/ai/src/chat/prompts`.
+
+This contract is required for runtime prompt resolution:
+
+- deterministic policy: `explicitVersion > channelDefault`
+- immutable artifact versions after publish
+- lifecycle status: `active | deprecated | blocked`
+- typed resolver failures with `_tag`
+- compatibility fallback only behind explicit compatibility mode
+
+## Artifact Contract
+
+Each prompt artifact includes:
+
+- `key`
+- `version`
+- `status`
+- `owner`
+- `inputSchema`
+- `contentHash`
+- `content`
+
+Artifacts are in-repo only. Runtime does not side-load prompts from remote systems.
+
+## Resolver Behavior
+
+`resolvePrompt` lives in `packages/ai/src/chat/prompts` and is consumed by use-cases.
+
+Resolution precedence:
+
+1. `explicitVersion` when provided
+2. `channelDefault` otherwise
+
+Failure model (typed tagged errors):
+
+- `PromptKeyNotFoundError`
+- `PromptVersionNotFoundError`
+- `PromptVersionBlockedError`
+- `PromptVariableSchemaMismatchError`
+
+## Compatibility Mode
+
+Compatibility mode allows a temporary legacy-inline fallback for migration windows.
+
+Current migration path:
+
+- use-case: `streamGeneralChat`
+- fallback mode: `GENERAL_CHAT_PROMPT_COMPATIBILITY_MODE`
+- sunset trigger: remove fallback after 30 days with zero fallback telemetry for `chat.general.system`
+
+## Observability Contract
+
+Use-case spans must include prompt resolution attributes:
+
+- `prompt.key`
+- `prompt.version`
+- `prompt.policy`
+- `prompt.fallbackUsed`
+- `prompt.failureReason` (fallback path only)
+
+Do not include interpolation payload values or user input in prompt telemetry.
+
+## Quickstart + Smoke Test
+
+1. Add a new prompt artifact in `packages/ai/src/chat/prompts/resolver.ts`.
+2. Resolve it from a use-case with `resolvePrompt`.
+3. Add resolver/use-case tests with `_tag` assertions for failure paths.
+4. Run smoke checks:
+
+```bash
+pnpm --filter @repo/ai test
+pnpm test:invariants
+```

--- a/packages/ai/src/chat/prompts/index.ts
+++ b/packages/ai/src/chat/prompts/index.ts
@@ -1,5 +1,8 @@
 export {
   resolvePrompt,
+  GENERAL_CHAT_PROMPT_KEY,
+  GENERAL_CHAT_PROMPT_CHANNEL,
+  GENERAL_CHAT_LEGACY_INLINE_FALLBACK,
   type ResolvePromptInput,
   type ResolvedPrompt,
 } from './resolver';

--- a/packages/ai/src/chat/prompts/resolver.ts
+++ b/packages/ai/src/chat/prompts/resolver.ts
@@ -45,9 +45,20 @@ export interface ResolvedPrompt {
 
 const EmptyVariablesSchema = Schema.Struct({});
 
+export const GENERAL_CHAT_PROMPT_KEY = 'chat.general.system';
+export const GENERAL_CHAT_PROMPT_CHANNEL: PromptChannel = 'chat.general';
+export const GENERAL_CHAT_LEGACY_INLINE_FALLBACK = `You are the default AI assistant for Agent Engine Template.
+
+Guidelines:
+- Be concise, clear, and practical.
+- Prefer structured answers when they help readability.
+- If you are uncertain, state assumptions explicitly.
+- Ask one clarifying question only when required.
+- Do not invent capabilities that are not requested.`;
+
 const PromptArtifacts: readonly PromptArtifact[] = [
   {
-    key: 'chat.general.system',
+    key: GENERAL_CHAT_PROMPT_KEY,
     version: 'v0',
     status: 'blocked',
     owner: 'ai-platform',
@@ -57,24 +68,17 @@ const PromptArtifacts: readonly PromptArtifact[] = [
     content: 'Blocked prompt placeholder',
   },
   {
-    key: 'chat.general.system',
+    key: GENERAL_CHAT_PROMPT_KEY,
     version: 'v1',
     status: 'active',
     owner: 'ai-platform',
     inputSchema: EmptyVariablesSchema,
     contentHash:
       'sha256:6632f5d91d856d5bfd2ec5cce9520517b5724345ee6f68d57743ce83a4d8b715',
-    content: `You are the default AI assistant for Agent Engine Template.
-
-Guidelines:
-- Be concise, clear, and practical.
-- Prefer structured answers when they help readability.
-- If you are uncertain, state assumptions explicitly.
-- Ask one clarifying question only when required.
-- Do not invent capabilities that are not requested.`,
+    content: GENERAL_CHAT_LEGACY_INLINE_FALLBACK,
   },
   {
-    key: 'chat.general.system',
+    key: GENERAL_CHAT_PROMPT_KEY,
     version: 'v2',
     status: 'deprecated',
     owner: 'ai-platform',
@@ -103,8 +107,8 @@ Guidelines:
 ];
 
 const PromptChannelDefaults: Record<PromptChannel, Record<string, string>> = {
-  'chat.general': {
-    'chat.general.system': 'v1',
+  [GENERAL_CHAT_PROMPT_CHANNEL]: {
+    [GENERAL_CHAT_PROMPT_KEY]: 'v1',
   },
 };
 

--- a/packages/ai/src/chat/use-cases/stream-general-chat.ts
+++ b/packages/ai/src/chat/use-cases/stream-general-chat.ts
@@ -6,7 +6,12 @@ import {
 } from 'ai';
 import { Effect } from 'effect';
 import { LLM } from '../../llm/service';
-import { resolvePrompt } from '../prompts';
+import {
+  GENERAL_CHAT_LEGACY_INLINE_FALLBACK,
+  GENERAL_CHAT_PROMPT_CHANNEL,
+  GENERAL_CHAT_PROMPT_KEY,
+  resolvePrompt,
+} from '../prompts';
 
 export interface StreamGeneralChatInput {
   readonly messages: UIMessage[];
@@ -40,7 +45,7 @@ const logPromptDecision = (
   }
 
   return baseLog.pipe(
-    Effect.annotateLogs('prompt.failure_reason', prompt.fallbackReason),
+    Effect.annotateLogs('prompt.failureReason', prompt.fallbackReason),
   );
 };
 
@@ -52,23 +57,16 @@ export const streamGeneralChat = (input: StreamGeneralChatInput) =>
       ? 'explicitVersion'
       : 'channelDefault';
     const prompt = yield* resolvePrompt({
-      key: 'chat.general.system',
-      channel: 'chat.general',
+      key: GENERAL_CHAT_PROMPT_KEY,
+      channel: GENERAL_CHAT_PROMPT_CHANNEL,
       version: input.promptVersion,
       compatibilityMode: input.promptCompatibilityMode ?? 'legacy-inline-fallback',
-      legacyFallback: `You are the default AI assistant for Agent Engine Template.
-
-Guidelines:
-- Be concise, clear, and practical.
-- Prefer structured answers when they help readability.
-- If you are uncertain, state assumptions explicitly.
-- Ask one clarifying question only when required.
-- Do not invent capabilities that are not requested.`,
+      legacyFallback: GENERAL_CHAT_LEGACY_INLINE_FALLBACK,
     }).pipe(
       Effect.withSpan('prompt.resolveForGeneralChat', {
         captureStackTrace: false,
         attributes: {
-          'prompt.key': 'chat.general.system',
+          'prompt.key': GENERAL_CHAT_PROMPT_KEY,
           'prompt.policy': promptPolicy,
         },
       }),
@@ -88,11 +86,18 @@ Guidelines:
 
     yield* logPromptDecision(promptPolicy, prompt);
 
-    return result.toUIMessageStream();
-  }).pipe(
-    Effect.withSpan('useCase.streamGeneralChat', {
-      attributes: {
-        'chat.messageCount': input.messages.length,
-      },
-    }),
-  );
+    return yield* Effect.sync(() => result.toUIMessageStream()).pipe(
+      Effect.withSpan('useCase.streamGeneralChat', {
+        attributes: {
+          'chat.messageCount': input.messages.length,
+          'prompt.key': prompt.key,
+          'prompt.version': prompt.version,
+          'prompt.policy': prompt.policy,
+          'prompt.outcome': prompt.outcome,
+          ...(prompt.fallbackReason
+            ? { 'prompt.failureReason': prompt.fallbackReason }
+            : {}),
+        },
+      }),
+    );
+  });


### PR DESCRIPTION
Fixes #47

## Summary
- add a git-versioned prompt registry in `packages/ai/src/prompts` with deterministic resolver policy (`explicitVersion > channelDefault`)
- introduce typed resolver errors for missing key/version, blocked version, and variable-schema mismatch
- migrate `streamGeneralChat` to resolve system prompt via registry and emit prompt decision telemetry attributes
- add resolver tests for precedence, failure matrix (`_tag` assertions), and compatibility fallback telemetry safety
- document prompt lifecycle, compatibility sunset trigger, and quickstart smoke test in `docs/architecture/prompt-registry.md`

## Aggregated Issues
- Fixes #47 - implemented prompt registry/versioning baseline for `streamGeneralChat`

## Workflow Routing
- #47: Feature Delivery (primary) + architecture-adr-guard (companion) + intake-triage
  - rationale: delivers new AI package behavior while preserving API handler/use-case boundary and codifying prompt observability/error contracts

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build
