### PR TITLE
feat(web): mobile thread create/switch controls in chat

### DIFF
--- a/apps/web/e2e/tests/chat-mobile-thread-controls.spec.ts
+++ b/apps/web/e2e/tests/chat-mobile-thread-controls.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+test('mobile users can create and switch chat threads', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const runId = Date.now();
+  const email = `mobile-thread-${runId}@example.com`;
+  const password = 'StrongPassword123!';
+
+  await page.getByRole('button', { name: 'Need an account? Create one' }).click();
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Create Account' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible();
+
+  await page.goto('/chat');
+
+  const storagePrefix = 'agent-engine-template.chat.threads.';
+  const seededThreads = [
+    {
+      id: 'thread_alpha',
+      title: 'Incident alpha',
+      createdAt: '2026-02-25T00:00:00.000Z',
+      updatedAt: '2026-02-25T00:00:00.000Z',
+      messages: [],
+    },
+    {
+      id: 'thread_beta',
+      title: 'Incident beta',
+      createdAt: '2026-02-25T00:00:00.000Z',
+      updatedAt: '2026-02-25T00:00:00.000Z',
+      messages: [],
+    },
+  ];
+
+  await page.waitForFunction(
+    (prefix) =>
+      Object.keys(window.localStorage).some((key) => key.startsWith(prefix)),
+    storagePrefix,
+  );
+
+  await page.evaluate(
+    ({ prefix, threads }) => {
+      const key = Object.keys(window.localStorage).find((entry) =>
+        entry.startsWith(prefix),
+      );
+
+      if (!key) {
+        throw new Error('Thread storage key not found');
+      }
+
+      window.localStorage.setItem(key, JSON.stringify(threads));
+    },
+    { prefix: storagePrefix, threads: seededThreads },
+  );
+
+  await page.reload();
+
+  const threadMenuButton = page.getByRole('button', { name: 'Open thread menu' });
+  const activeThreadLabels = page.getByLabel('Current active thread');
+
+  await expect(threadMenuButton).toContainText('Threads (2)');
+  await expect(activeThreadLabels.first()).toContainText('Incident alpha');
+
+  await threadMenuButton.click();
+  await page.getByRole('menuitem', { name: 'Incident beta' }).click();
+  await expect(activeThreadLabels.first()).toContainText('Incident beta');
+
+  await threadMenuButton.click();
+  await page.getByRole('menuitem', { name: '+ New thread' }).click();
+  await expect(threadMenuButton).toContainText('Threads (3)');
+  await expect(activeThreadLabels.first()).toContainText('New chat');
+
+  await threadMenuButton.click();
+  await page.getByRole('menuitem', { name: 'Incident alpha' }).click();
+  await expect(activeThreadLabels.first()).toContainText('Incident alpha');
+});

--- a/apps/web/src/pages/chat.tsx
+++ b/apps/web/src/pages/chat.tsx
@@ -1,6 +1,14 @@
 import { useChat } from '@ai-sdk/react';
 import { eventIteratorToUnproxiedDataStream } from '@repo/api/client';
 import { Button } from '@repo/ui/components/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@repo/ui/components/dropdown-menu';
 import { Textarea } from '@repo/ui/components/textarea';
 import { useNavigate } from '@tanstack/react-router';
 import { type UIMessage } from 'ai';
@@ -19,6 +27,122 @@ import {
   saveThreads,
 } from '@/lib/chat-utils';
 import { readErrorMessage } from '@/lib/run-utils';
+
+interface ThreadListProps {
+  threads: StoredThread[];
+  activeThreadId: string | null;
+  onSelect: (threadId: string) => void;
+}
+
+function ThreadList({ threads, activeThreadId, onSelect }: ThreadListProps) {
+  if (threads.length === 0) {
+    return (
+      <div className="empty-state rounded-xl py-6">
+        <p className="text-sm text-muted-foreground">No threads yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-1">
+      {threads.map((thread, index) => (
+        <li
+          key={thread.id}
+          className={`animate-fade-in stagger-${String(Math.min(index + 1, 6))}`}
+        >
+          <button
+            type="button"
+            onClick={() => onSelect(thread.id)}
+            className={
+              thread.id === activeThreadId
+                ? 'w-full rounded-xl border border-primary/30 bg-primary/5 p-3 text-left transition-all duration-200'
+                : 'w-full rounded-xl border border-transparent p-3 text-left transition-all duration-200 hover:bg-muted/50'
+            }
+          >
+            <p className="truncate text-sm font-medium text-foreground">
+              {thread.title}
+            </p>
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {thread.messages.length === 0
+                ? 'No messages yet'
+                : extractMessageText(thread.messages[thread.messages.length - 1]!)}
+            </p>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface MobileThreadMenuProps {
+  threads: StoredThread[];
+  activeThreadId: string | null;
+  activeThreadTitle: string;
+  onCreateThread: () => void;
+  onSelectThread: (threadId: string) => void;
+}
+
+function MobileThreadMenu({
+  threads,
+  activeThreadId,
+  activeThreadTitle,
+  onCreateThread,
+  onSelectThread,
+}: MobileThreadMenuProps) {
+  return (
+    <div className="mb-4 flex items-center justify-between gap-3 lg:hidden">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" aria-label="Open thread menu">
+            Threads ({threads.length})
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-[16rem]"
+        >
+          <DropdownMenuLabel>Switch thread</DropdownMenuLabel>
+          {threads.length === 0 ? (
+            <DropdownMenuItem disabled>No threads yet.</DropdownMenuItem>
+          ) : (
+            threads.map((thread) => (
+              <DropdownMenuItem
+                key={thread.id}
+                onSelect={() => onSelectThread(thread.id)}
+              >
+                {thread.id === activeThreadId ? 'Current - ' : ''}
+                {thread.title}
+              </DropdownMenuItem>
+            ))
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={onCreateThread}>+ New thread</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <p
+        className="max-w-[55%] truncate text-xs font-medium text-muted-foreground"
+        aria-live="polite"
+        aria-label="Current active thread"
+      >
+        {activeThreadTitle}
+      </p>
+    </div>
+  );
+}
+
+function MobileActiveThreadBadge({ title }: { title: string }) {
+  return (
+    <div className="mb-2 flex items-center justify-between rounded-xl border border-border/60 bg-background/60 px-3 py-2 lg:hidden">
+      <p className="text-meta">Active thread</p>
+      <p
+        className="max-w-[70%] truncate text-xs font-medium text-foreground"
+        aria-label="Current active thread"
+      >
+        {title}
+      </p>
+    </div>
+  );
+}
 
 export function ChatPage() {
   const { data: session } = authClient.useSession();
@@ -97,6 +221,12 @@ export function ChatPage() {
   const threadsWithActiveMessages = useMemo(
     () => applyActiveMessages(threads),
     [applyActiveMessages, threads],
+  );
+  const activeThread = useMemo(
+    () =>
+      threadsWithActiveMessages.find((thread) => thread.id === activeThreadId) ??
+      null,
+    [activeThreadId, threadsWithActiveMessages],
   );
 
   const threadsRef = useRef<StoredThread[]>(threadsWithActiveMessages);
@@ -177,47 +307,25 @@ export function ChatPage() {
           </Button>
         </div>
         <div className="flex-1 overflow-y-auto p-3 pt-0">
-          {threadsWithActiveMessages.length === 0 ? (
-            <div className="empty-state rounded-xl py-6">
-              <p className="text-sm text-muted-foreground">No threads yet.</p>
-            </div>
-          ) : (
-            <ul className="space-y-1">
-              {threadsWithActiveMessages.map((thread, index) => (
-                <li
-                  key={thread.id}
-                  className={`animate-fade-in stagger-${String(Math.min(index + 1, 6))}`}
-                >
-                  <button
-                    type="button"
-                    onClick={() => selectThread(thread.id)}
-                    className={
-                      thread.id === activeThreadId
-                        ? 'w-full rounded-xl border border-primary/30 bg-primary/5 p-3 text-left transition-all duration-200'
-                        : 'w-full rounded-xl border border-transparent p-3 text-left transition-all duration-200 hover:bg-muted/50'
-                    }
-                  >
-                    <p className="truncate text-sm font-medium text-foreground">
-                      {thread.title}
-                    </p>
-                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                      {thread.messages.length === 0
-                        ? 'No messages yet'
-                        : extractMessageText(
-                            thread.messages[thread.messages.length - 1]!,
-                          )}
-                    </p>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
+          <ThreadList
+            threads={threadsWithActiveMessages}
+            activeThreadId={activeThreadId}
+            onSelect={selectThread}
+          />
         </div>
       </aside>
 
       {/* Chat Area */}
       <div className="flex flex-1 flex-col overflow-hidden">
         <div className="flex-1 overflow-y-auto p-4 lg:p-6">
+          <MobileThreadMenu
+            threads={threadsWithActiveMessages}
+            activeThreadId={activeThreadId}
+            activeThreadTitle={activeThread?.title ?? 'New chat'}
+            onCreateThread={createThread}
+            onSelectThread={selectThread}
+          />
+
           {messages.length === 0 ? (
             <div className="flex h-full items-center justify-center">
               <div className="empty-state-lg w-full max-w-md animate-fade-in-up">
@@ -264,6 +372,7 @@ export function ChatPage() {
         {/* Composer */}
         <div className="shrink-0 border-t border-border bg-card/80 p-4 backdrop-blur-sm">
           <div className="mx-auto max-w-3xl">
+            <MobileActiveThreadBadge title={activeThread?.title ?? 'New chat'} />
             {error ? (
               <p className="mb-2 text-sm text-destructive">
                 {error.message || 'Streaming failed.'}


### PR DESCRIPTION
## Summary
- add mobile-visible thread menu on Chat to switch existing threads and create new ones
- surface active thread identity in mobile chat area and composer for context clarity
- add Playwright coverage for mobile thread create/switch behavior

Fixes #49

## Aggregated Issues
- Fixes #49 - [Product Owner] Add mobile thread create/switch controls in Chat

## Workflow Routing
- #49 -> Feature Delivery (primary)
- Companion skills: frontend-design (mobile UX intent), tanstack-vite (apps/web guardrails), test-surface-steward (Playwright coverage selection)

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`
- Focused check: `pnpm --filter web test:e2e apps/web/e2e/tests/chat-mobile-thread-controls.spec.ts` (timed out in auth loading spinner in this environment)

## Research Log Update
- Not applicable (no Research Trace/paper link in issue)
