### PR TITLE
feat(web): standardize async-work run terminology

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -128,7 +128,7 @@ function SignOutIcon() {
 const navItems = [
   { to: '/' as const, label: 'Dashboard', Icon: DashboardIcon, exact: true },
   { to: '/chat' as const, label: 'Chat', Icon: ChatIcon, exact: false },
-  { to: '/jobs' as const, label: 'Jobs', Icon: JobsIcon, exact: false },
+  { to: '/jobs' as const, label: 'Runs', Icon: JobsIcon, exact: false },
 ];
 
 /* ─── App Shell ─── */

--- a/apps/web/src/pages/chat.tsx
+++ b/apps/web/src/pages/chat.tsx
@@ -281,16 +281,14 @@ export function ChatPage() {
         threadId: activeThreadId ?? undefined,
       });
       setDraft('');
-      toast.success('Background run queued.', {
+      toast.success('Run queued.', {
         action: {
-          label: 'View Jobs',
+          label: 'View Runs',
           onClick: () => void navigate({ to: '/jobs' }),
         },
       });
     } catch (queueError) {
-      toast.error(
-        readErrorMessage(queueError, 'Failed to queue background run.'),
-      );
+      toast.error(readErrorMessage(queueError, 'Failed to queue run.'));
     } finally {
       setIsQueueingRun(false);
     }
@@ -334,7 +332,7 @@ export function ChatPage() {
                 </div>
                 <p className="empty-state-title">Start a conversation</p>
                 <p className="empty-state-description">
-                  Send a message or queue a background run to get started.
+                  Send a message or queue a run to get started.
                 </p>
               </div>
             </div>
@@ -407,7 +405,7 @@ export function ChatPage() {
                     isQueueingRun || isStreaming || draft.trim().length === 0
                   }
                 >
-                  {isQueueingRun ? 'Queueing...' : 'Background Run'}
+                  {isQueueingRun ? 'Queueing...' : 'Queue Run'}
                 </Button>
                 <Button
                   size="sm"

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -219,9 +219,9 @@ export function DashboardPage() {
             <LayersSmallIcon />
           </div>
           <div>
-            <p className="action-card-title">Job Queue</p>
+            <p className="action-card-title">Run Queue</p>
             <p className="action-card-description">
-              View and manage background runs
+              View and manage runs
             </p>
           </div>
         </Link>

--- a/apps/web/src/pages/jobs.tsx
+++ b/apps/web/src/pages/jobs.tsx
@@ -174,11 +174,9 @@ export function JobsPage() {
     <div className="page-container animate-fade-in">
       {/* Header */}
       <div className="mb-8">
-        <p className="page-eyebrow">Jobs</p>
-        <h1 className="page-title">Job Queue</h1>
-        <p className="text-body mt-2">
-          Manage and monitor background runs.
-        </p>
+        <p className="page-eyebrow">Runs</p>
+        <h1 className="page-title">Run Queue</h1>
+        <p className="text-body mt-2">Manage and monitor runs.</p>
       </div>
 
       {/* Stats */}
@@ -230,7 +228,7 @@ export function JobsPage() {
               void onQueueRun();
             }
           }}
-          placeholder="Enter a prompt for the background run..."
+          placeholder="Enter a prompt for the run..."
           className="min-h-[80px] resize-none"
           aria-label="Run prompt"
         />

--- a/apps/web/src/terminology-consistency.test.ts
+++ b/apps/web/src/terminology-consistency.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const routeSurfaceFiles = [
+  'components/app-shell.tsx',
+  'pages/dashboard.tsx',
+  'pages/chat.tsx',
+  'pages/jobs.tsx',
+] as const;
+
+const forbiddenTerms = ['Jobs', 'Job Queue', 'Background Run'] as const;
+
+const quotedStringPattern = /(['"`])(?:\\.|(?!\1)[\s\S])*?\1/g;
+
+function extractQuotedStrings(source: string): string[] {
+  const matches = source.match(quotedStringPattern) ?? [];
+  return matches.map((quoted) => quoted.slice(1, -1));
+}
+
+describe('async work terminology consistency', () => {
+  it('avoids mixed legacy terms in targeted route surfaces', () => {
+    for (const relativeFile of routeSurfaceFiles) {
+      const fullPath = path.resolve(__dirname, relativeFile);
+      const source = readFileSync(fullPath, 'utf8');
+      const quotedStrings = extractQuotedStrings(source);
+
+      for (const forbiddenTerm of forbiddenTerms) {
+        const offenders = quotedStrings.filter((value) =>
+          value.includes(forbiddenTerm),
+        );
+        expect(
+          offenders,
+          `${relativeFile} contains legacy term "${forbiddenTerm}" in UI copy`,
+        ).toHaveLength(0);
+      }
+    }
+  });
+});

--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -2,11 +2,17 @@
 
 ## Current Surface
 
-- **App shell** — sidebar navigation (Dashboard, Chat, Jobs) + mobile drawer
+- **App shell** — sidebar navigation (Dashboard, Chat, Runs) + mobile drawer
 - **Auth gate** — sign-in / sign-up form
 - **Dashboard** — stat cards, quick action links, recent runs list
 - **Chat** — thread sidebar + message stream + composer
-- **Jobs** — run stats, create-run form, full run list with SSE updates
+- **Runs page (`/jobs`)** — run stats, create-run form, full run list with SSE updates
+
+## UX Copy Canonical Terms
+
+- Use **Run / Runs** as the canonical user-facing noun for asynchronous work.
+- Keep route path `/jobs` as an implementation detail where needed, but avoid
+  user-facing labels like "Jobs", "Job Queue", or "Background Run".
 
 ## Rules
 


### PR DESCRIPTION
Fixes #50

## Summary
- standardize user-facing async-work terminology to `Run/Runs` across app shell, Dashboard, Chat, and Runs page surfaces
- keep `/jobs` route path unchanged while removing mixed labels like `Jobs`, `Job Queue`, and `Background Run` from UI copy
- add a lightweight frontend regression test that scans targeted route-surface UI strings for forbidden legacy terms
- document canonical async-work copy guidance in frontend component docs

## Aggregated Issues
- Fixes #50 (fully resolved)

## Workflow Routing
- #50 -> Feature Delivery (`feature-delivery`, `intake-triage`, `tanstack-vite`)
  - Rationale: focused frontend UX terminology alignment with guardrailed route-surface test coverage.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build
