### PR TITLE
fix: harden agent-engine lane bootstrap and wrapper validation

### DIFF
--- a/agent-engine/automations/agent-engine-researcher/agent-engine-researcher.md
+++ b/agent-engine/automations/agent-engine-researcher/agent-engine-researcher.md
@@ -9,6 +9,16 @@ Use gpt-5.3-codex with reasoning effort xhigh and keep reasoning at xhigh for th
 
 Preflight GitHub access first by running `gh auth status`, `gh repo view --json viewerPermission`, and `gh issue list --limit 1`; if any command fails, stop and report blocker details in inbox update and automation memory.
 
+Runtime bootstrap + preflight (required before research logic in fresh worktrees):
+1. Run `zsh -lic 'cd "$PWD" && pnpm install --frozen-lockfile --prefer-offline'`.
+2. If install fails due to transient network/DNS errors (`ENOTFOUND`, `EAI_AGAIN`, `ECONNRESET`, `ETIMEDOUT`):
+  - check registries: `npm config get registry` and `pnpm config get registry`
+  - retry: `npm_config_registry=https://registry.npmjs.org pnpm install --frozen-lockfile`
+  - retry once more: `npm_config_registry=https://registry.npmjs.com pnpm install --frozen-lockfile`
+  - if dependency-state corruption is indicated, remove `node_modules` once and retry install
+3. Run runtime preflight: `zsh -lic 'cd "$PWD" && pnpm workflow-memory:retrieve --workflow "Periodic Scans" --limit 1 --min-score 0'`.
+4. If bootstrap/preflight still fails, stop early before research execution and record diagnostics in run output and workflow memory (`node -v`, `pnpm -v`, `npm -v`, `nslookup registry.npmjs.org`, `curl -I https://registry.npmjs.org/`).
+
 GitHub interaction policy: use `gh` CLI for all GitHub interactions in this run (issue/PR search/read/write, comments, labels, reactions, and metadata). Do not use browser/manual edits or non-`gh` GitHub clients.
 
 Random-walk protocol:

--- a/agent-engine/scripts/__tests__/agent-engine-researcher-loop.test.ts
+++ b/agent-engine/scripts/__tests__/agent-engine-researcher-loop.test.ts
@@ -1,0 +1,23 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('agent-engine researcher playbook', () => {
+  it('requires runtime bootstrap and workflow-memory preflight before research logic', async () => {
+    const playbookPath = path.join(
+      process.cwd(),
+      'agent-engine',
+      'automations',
+      'agent-engine-researcher',
+      'agent-engine-researcher.md',
+    );
+    const playbook = await readFile(playbookPath, 'utf8');
+
+    expect(playbook).toContain("pnpm install --frozen-lockfile --prefer-offline");
+    expect(playbook).toContain("npm_config_registry=https://registry.npmjs.org pnpm install --frozen-lockfile");
+    expect(playbook).toContain("npm_config_registry=https://registry.npmjs.com pnpm install --frozen-lockfile");
+    expect(playbook).toContain(
+      'pnpm workflow-memory:retrieve --workflow "Periodic Scans" --limit 1 --min-score 0',
+    );
+  });
+});

--- a/agent-engine/scripts/__tests__/workflow-registry-validation.test.ts
+++ b/agent-engine/scripts/__tests__/workflow-registry-validation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { readWorkflowRegistry } from '../workflows/registry';
+
+let missingPathSuffixes: string[] = [];
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  return {
+    ...actual,
+    access: vi.fn(async (targetPath: Parameters<typeof actual.access>[0], mode?: Parameters<typeof actual.access>[1]) => {
+      const normalizedPath = String(targetPath).replaceAll('\\', '/');
+      if (missingPathSuffixes.some((suffix) => normalizedPath.endsWith(suffix))) {
+        const error = new Error(`ENOENT: ${normalizedPath}`) as NodeJS.ErrnoException;
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return actual.access(targetPath, mode);
+    }),
+  };
+});
+
+afterEach(() => {
+  missingPathSuffixes = [];
+});
+
+describe('workflow registry validation', () => {
+  it('fails when an automation lane toml wrapper is missing', async () => {
+    missingPathSuffixes = ['agent-engine/automations/ready-for-dev-executor/ready-for-dev-executor.toml'];
+
+    await expect(readWorkflowRegistry()).rejects.toThrow(
+      'agent-engine/automations/ready-for-dev-executor/ready-for-dev-executor.toml',
+    );
+  });
+
+  it('fails when an automation lane markdown playbook path is missing', async () => {
+    missingPathSuffixes = ['agent-engine/automations/ready-for-dev-executor/ready-for-dev-executor.md'];
+
+    await expect(readWorkflowRegistry()).rejects.toThrow(
+      'agent-engine/automations/ready-for-dev-executor/ready-for-dev-executor.md',
+    );
+  });
+});

--- a/agent-engine/scripts/workflows/registry.ts
+++ b/agent-engine/scripts/workflows/registry.ts
@@ -8,6 +8,7 @@ const workflowsDir = resolve(scriptDir, "../../workflows");
 const registryPath = resolve(workflowsDir, "registry.json");
 const schemaPath = resolve(workflowsDir, "registry.schema.json");
 const repoRoot = resolve(workflowsDir, "../..");
+const AUTOMATION_LANE_FILE_EXTENSIONS = ["md", "toml"];
 
 async function pathExists(targetPath) {
   try {
@@ -116,20 +117,24 @@ export async function readWorkflowRegistry() {
     }
 
     for (const lane of entry.automationLanes ?? []) {
-      const lanePath = resolve(
-        repoRoot,
-        "agent-engine",
-        "automations",
-        lane,
-        `${lane}.md`,
-      );
-      validationTasks.push(
-        pathExists(lanePath).then((exists) => {
-          if (!exists) {
-            issues.push(`Missing automation lane for "${entry.id}": agent-engine/automations/${lane}/${lane}.md`);
-          }
-        }),
-      );
+      for (const extension of AUTOMATION_LANE_FILE_EXTENSIONS) {
+        const lanePath = resolve(
+          repoRoot,
+          "agent-engine",
+          "automations",
+          lane,
+          `${lane}.${extension}`,
+        );
+        validationTasks.push(
+          pathExists(lanePath).then((exists) => {
+            if (!exists) {
+              issues.push(
+                `Missing automation lane file for "${entry.id}": agent-engine/automations/${lane}/${lane}.${extension}`,
+              );
+            }
+          }),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #62
Fixes #63

## Summary
- add required runtime bootstrap + workflow-memory preflight steps to the `agent-engine-researcher` lane playbook, including retry/diagnostic stop behavior
- enforce workflow registry validation parity for automation lanes by requiring both `agent-engine/automations/<lane>/<lane>.md` and `<lane>.toml`
- add focused tests for researcher bootstrap contract and workflow-registry missing-lane-file failures

## Aggregated Issues
- Fixes #62 - Add required runtime bootstrap preflight to agent-engine-researcher lane
- Fixes #63 - Enforce automation wrapper parity in workflow registry validation

## Workflow Routing
- #62 -> Self-Improvement workflow using `self-improvement` skill (lane contract drift prevention)
- #63 -> Self-Improvement workflow using `self-improvement` skill (registry guardrail hardening)

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build

## Research Log Update
- No external-paper Research Trace issues were implemented in this bundle, so `research/implemented-ideas.md` was not updated.
