### PR TITLE
feat: enforce run use-case auth and effect-runner boundaries

### DIFF
--- a/apps/worker/src/__tests__/unified-worker.test.ts
+++ b/apps/worker/src/__tests__/unified-worker.test.ts
@@ -59,7 +59,7 @@ const withQueue = (queue: QueueService) =>
   Effect.provide(Layer.succeed(Queue, queue));
 
 describe('handleCompletedRun', () => {
-  it('emits run_completed for valid run results', () => {
+  it('emits run_completed for valid run results', async () => {
     const publishEvent = vi.fn<(userId: string, event: SSEEvent) => void>();
     const result: RunResult = {
       title: 'Title',
@@ -68,12 +68,14 @@ describe('handleCompletedRun', () => {
       nextActions: ['C'],
     };
 
-    handleCompletedRun(
-      publishEvent,
-      'user_test',
-      createJob({
-        result,
-      }),
+    await Effect.runPromise(
+      handleCompletedRun(
+        publishEvent,
+        'user_test',
+        createJob({
+          result,
+        }),
+      ),
     );
 
     expect(publishEvent).toHaveBeenCalledTimes(1);
@@ -87,15 +89,17 @@ describe('handleCompletedRun', () => {
     );
   });
 
-  it('emits run_failed for completed jobs with invalid result payload', () => {
+  it('emits run_failed for completed jobs with invalid result payload', async () => {
     const publishEvent = vi.fn<(userId: string, event: SSEEvent) => void>();
 
-    handleCompletedRun(
-      publishEvent,
-      'user_test',
-      createJob({
-        result: { nope: 'invalid' },
-      }),
+    await Effect.runPromise(
+      handleCompletedRun(
+        publishEvent,
+        'user_test',
+        createJob({
+          result: { nope: 'invalid' },
+        }),
+      ),
     );
 
     expect(publishEvent).toHaveBeenCalledTimes(1);

--- a/apps/worker/src/base-worker.ts
+++ b/apps/worker/src/base-worker.ts
@@ -117,11 +117,13 @@ const logAndSwallow = (label: string, error: unknown) =>
  * Handle a job failure (error or defect) by marking it failed and notifying.
  * Shared between `catchAll` and `catchAllDefect` in the forked job pipeline.
  */
-const handleJobFailure = <TPayload>(
+const handleJobFailure = <TPayload, R extends SharedServices>(
   queue: QueueService,
   job: Job,
   errorMessage: string,
-  onJobComplete: ((job: Job<TPayload>) => void) | undefined,
+  onJobComplete:
+    | ((job: Job<TPayload>) => Effect.Effect<void, never, R>)
+    | undefined,
 ) =>
   queue.updateJobStatus(job.id, JobStatus.FAILED, undefined, errorMessage).pipe(
     Effect.tap((result) =>
@@ -130,7 +132,7 @@ const handleJobFailure = <TPayload>(
       ),
     ),
     Effect.tap((result) =>
-      Effect.sync(() => onJobComplete?.(result as Job<TPayload>)),
+      onJobComplete ? onJobComplete(result as Job<TPayload>) : Effect.void,
     ),
     Effect.catchAll((updateErr) =>
       Effect.logError(
@@ -149,7 +151,9 @@ export interface CreateWorkerOptions<
   processJob: (
     job: Job<TPayload>,
   ) => Effect.Effect<unknown, JobProcessingError, R>;
-  onJobComplete?: (job: Job<TPayload>) => void;
+  onJobComplete?: (
+    job: Job<TPayload>,
+  ) => Effect.Effect<void, never, R>;
   onPollCycle?: (
     pollCount: number,
   ) => Effect.Effect<void, never, SharedServices>;
@@ -194,7 +198,7 @@ export const createWorker = <
     );
 
   const notifyJobComplete = (job: Job) =>
-    Effect.sync(() => onJobComplete?.(job as Job<TPayload>));
+    onJobComplete ? onJobComplete(job as Job<TPayload>) : Effect.void;
 
   const closeJobScope = (scope: CloseableScope) =>
     Effect.sync(() => {
@@ -225,10 +229,15 @@ export const createWorker = <
         ),
         Effect.tap(notifyJobComplete),
         Effect.catchAll((err) =>
-          handleJobFailure(queue, job, formatError(err), onJobComplete),
+          handleJobFailure<TPayload, R>(
+            queue,
+            job,
+            formatError(err),
+            onJobComplete,
+          ),
         ),
         Effect.catchAllDefect((defect) =>
-          handleJobFailure(
+          handleJobFailure<TPayload, R>(
             queue,
             job,
             `Unexpected defect: ${formatError(defect)}`,
@@ -355,16 +364,14 @@ export const createWorker = <
       }),
     ).pipe(
       Effect.annotateLogs('worker', name),
+      Effect.tapError((error) =>
+        Effect.logWarning(`${name} error, will retry...`).pipe(
+          Effect.annotateLogs('error', String(error)),
+        ),
+      ),
       Effect.retry({
         schedule: retrySchedule,
-        while: (error) => {
-          Effect.runSync(
-            Effect.logWarning(`${name} error, will retry...`).pipe(
-              Effect.annotateLogs('error', String(error)),
-            ),
-          );
-          return true;
-        },
+        while: () => true,
       }),
       Effect.tapError((error) =>
         Effect.logError(

--- a/apps/worker/src/unified-worker.ts
+++ b/apps/worker/src/unified-worker.ts
@@ -131,34 +131,42 @@ const parseRunResult = (value: unknown): ParsedRunResult => {
   }
 };
 
-const logRunResultDecodeFailure = (jobId: string, parseErrorSummary: string) => {
-  Effect.runSync(
-    Effect.logWarning('run.result.decode_failed').pipe(
-      Effect.annotateLogs('queue.job.id', jobId),
-      Effect.annotateLogs('source.path', RUN_RESULT_DECODE_SOURCE_PATH),
-      Effect.annotateLogs('parse.error.summary', parseErrorSummary),
-    ),
+const logRunResultDecodeFailure = (jobId: string, parseErrorSummary: string) =>
+  Effect.logWarning('run.result.decode_failed').pipe(
+    Effect.annotateLogs('queue.job.id', jobId),
+    Effect.annotateLogs('source.path', RUN_RESULT_DECODE_SOURCE_PATH),
+    Effect.annotateLogs('parse.error.summary', parseErrorSummary),
   );
-};
 
 export const handleCompletedRun = (
   publishEvent: PublishEvent | undefined,
   userId: string,
   job: Job<RunJobPayload>,
-): void => {
-  const parsed = parseRunResult(job.result);
+): Effect.Effect<void, never> =>
+  Effect.gen(function* () {
+    const parsed = parseRunResult(job.result);
+    const runResult = parsed.result;
 
-  if (parsed.result) {
-    emitRunCompleted(publishEvent, userId, job.id, parsed.result);
-    return;
-  }
+    if (runResult) {
+      yield* Effect.sync(() =>
+        emitRunCompleted(publishEvent, userId, job.id, runResult),
+      );
+      return;
+    }
 
-  if (parsed.parseErrorSummary) {
-    logRunResultDecodeFailure(job.id, parsed.parseErrorSummary);
-  }
+    if (parsed.parseErrorSummary) {
+      yield* logRunResultDecodeFailure(job.id, parsed.parseErrorSummary);
+    }
 
-  emitRunFailed(publishEvent, userId, job.id, INVALID_COMPLETED_RUN_RESULT_ERROR);
-};
+    yield* Effect.sync(() =>
+      emitRunFailed(
+        publishEvent,
+        userId,
+        job.id,
+        INVALID_COMPLETED_RUN_RESULT_ERROR,
+      ),
+    );
+  });
 
 const shouldRunStaleCheck = (pollCount: number, checkEveryNPolls: number) =>
   pollCount > 0 && pollCount % checkEveryNPolls === 0;
@@ -285,7 +293,7 @@ export function createUnifiedWorker(config: UnifiedWorkerConfig): Worker {
     );
 
   const onJobComplete = (job: Job<RunJobPayload>) => {
-    if (job.type !== JobType.PROCESS_AI_RUN) return;
+    if (job.type !== JobType.PROCESS_AI_RUN) return Effect.void;
 
     const userId =
       typeof job.payload?.userId === 'string' && job.payload.userId.length > 0
@@ -293,18 +301,21 @@ export function createUnifiedWorker(config: UnifiedWorkerConfig): Worker {
         : job.createdBy;
 
     if (job.status === JobStatus.COMPLETED) {
-      handleCompletedRun(config.publishEvent, userId, job);
-      return;
+      return handleCompletedRun(config.publishEvent, userId, job);
     }
 
     if (job.status === JobStatus.FAILED) {
-      emitRunFailed(
-        config.publishEvent,
-        userId,
-        job.id,
-        job.error ?? 'Run failed',
+      return Effect.sync(() =>
+        emitRunFailed(
+          config.publishEvent,
+          userId,
+          job.id,
+          job.error ?? 'Run failed',
+        ),
       );
     }
+
+    return Effect.void;
   };
 
   return createWorker({

--- a/docs/patterns/effect-runtime.md
+++ b/docs/patterns/effect-runtime.md
@@ -16,6 +16,13 @@ Per-request context (current user, request id) is added at handler execution tim
 - Do not instantiate new runtimes inside handlers.
 - Keep runtime layer graph deterministic.
 - Inject test layers in integration tests.
+- Keep `Effect.runSync` calls at explicit transport/process boundaries only.
+
+## Approved `Effect.runSync` Boundaries
+
+- `packages/api/src/server/index.ts` inside oRPC `onError` interceptor.
+
+`Effect.runSync` in worker or use-case internals is forbidden; compose and return `Effect` values instead.
 
 ## Layer Constructor Policy
 

--- a/docs/testing/invariants.md
+++ b/docs/testing/invariants.md
@@ -87,6 +87,15 @@ Required for all agent-authored backend changes.
 | `Layer.sync` in non-test runtime files must receive class/factory-style constructor functions | Misusing sync layers for prebuilt values or plain objects |
 | `Layer.effect` in non-test runtime files must use Effect-backed constructor expressions or identifiers bound to `Effect.*` | Losing dependency-aware initialization semantics in runtime layer graphs |
 
+### Effect Runner Boundary Invariants
+<!-- enforced-by: invariant-test -->
+
+**File:** `packages/testing/src/__tests__/effect-runner-boundaries.invariants.test.ts`
+
+| Rule | What It Prevents |
+|---|---|
+| `Effect.runSync` is forbidden in runtime internals outside explicit allowlisted transport boundaries | Imperative effect execution leaking into compositional worker/api internals |
+
 ### Telemetry Lifecycle Invariants
 <!-- enforced-by: invariant-test -->
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start": "turbo run start",
     "test": "vitest run",
     "test:scripts": "vitest run --config agent-engine/scripts/vitest.config.ts",
-    "test:invariants": "vitest run packages/api/src/server/__tests__/effect-handler.invariants.test.ts packages/api/src/server/__tests__/error-assertions.invariants.test.ts packages/api/src/server/__tests__/chat-handler.invariants.test.ts packages/api/src/server/__tests__/router-handler.invariants.test.ts packages/api/src/contracts/__tests__/chat-contract.invariants.test.ts packages/testing/src/__tests__/effect-layer-constructor.invariants.test.ts packages/testing/src/__tests__/telemetry-lifecycle.invariants.test.ts packages/testing/src/__tests__/docs-invariants.test.ts",
+    "test:invariants": "vitest run packages/api/src/server/__tests__/effect-handler.invariants.test.ts packages/api/src/server/__tests__/error-assertions.invariants.test.ts packages/api/src/server/__tests__/chat-handler.invariants.test.ts packages/api/src/server/__tests__/router-handler.invariants.test.ts packages/api/src/contracts/__tests__/chat-contract.invariants.test.ts packages/testing/src/__tests__/effect-layer-constructor.invariants.test.ts packages/testing/src/__tests__/effect-runner-boundaries.invariants.test.ts packages/testing/src/__tests__/telemetry-lifecycle.invariants.test.ts packages/testing/src/__tests__/docs-invariants.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:coverage:api": "pnpm --filter @repo/api test:coverage",

--- a/packages/api/src/server/use-cases/__tests__/runs.test.ts
+++ b/packages/api/src/server/use-cases/__tests__/runs.test.ts
@@ -1,3 +1,4 @@
+import { type User } from '@repo/auth';
 import {
   Queue,
   QueueError,
@@ -9,7 +10,6 @@ import {
 } from '@repo/queue';
 import { Effect, Layer } from 'effect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { User } from '@repo/auth/policy';
 import {
   SSEPublisher,
   type SSEPublisherService,
@@ -21,6 +21,11 @@ const TEST_USER: User = {
   email: 'test@example.com',
   name: 'Test User',
   role: 'user',
+};
+
+const UNAUTHORIZED_ROLE_USER = {
+  ...TEST_USER,
+  role: 'viewer' as unknown as User['role'],
 };
 
 type RunJob = TypedJob<typeof QueueJobType.PROCESS_AI_RUN>;
@@ -157,6 +162,34 @@ describe('runs use-cases', () => {
     expect(error.message).toBe('queue unavailable');
   });
 
+  it('fails create run with typed forbidden error for unauthorized roles', async () => {
+    let enqueueCalls = 0;
+
+    const queue = createMockQueueService({
+      enqueue: ((type, payload, userId) => {
+        enqueueCalls += 1;
+        return Effect.succeed(
+          createJob({ type, payload: payload as RunPayload, createdBy: userId }),
+        ) as ReturnType<QueueService['enqueue']>;
+      }) as QueueService['enqueue'],
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        createRunUseCase({
+          user: UNAUTHORIZED_ROLE_USER,
+          input: {
+            prompt: 'Plan quarterly roadmap',
+          },
+        }).pipe(withQueueAndPublisher(queue)),
+      ),
+    );
+
+    expect(error._tag).toBe('ForbiddenError');
+    expect(error.message).toContain('Requires user or admin role');
+    expect(enqueueCalls).toBe(0);
+  });
+
   it('scopes list runs to user ownership and delegates order + limit to queue', async () => {
     let listUserId: string | undefined;
     let listOptions: Parameters<QueueService['getJobsByUser']>[1] | undefined;
@@ -242,5 +275,31 @@ describe('runs use-cases', () => {
 
     expect(error._tag).toBe('QueueError');
     expect(error.message).toBe('query failed');
+  });
+
+  it('fails list runs with typed forbidden error for unauthorized roles', async () => {
+    let listCalls = 0;
+
+    const queue = createMockQueueService({
+      getJobsByUser: ((userId, _options) => {
+        listCalls += 1;
+        return Effect.succeed([
+          createJob({ id: 'job_1' as RunJob['id'], createdBy: userId }),
+        ]) as ReturnType<QueueService['getJobsByUser']>;
+      }) as QueueService['getJobsByUser'],
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        listRunsUseCase({
+          user: UNAUTHORIZED_ROLE_USER,
+          input: { limit: 1 },
+        }).pipe(withQueueAndPublisher(queue)),
+      ),
+    );
+
+    expect(error._tag).toBe('ForbiddenError');
+    expect(error.message).toContain('Requires user or admin role');
+    expect(listCalls).toBe(0);
   });
 });

--- a/packages/api/src/server/use-cases/runs.ts
+++ b/packages/api/src/server/use-cases/runs.ts
@@ -1,11 +1,16 @@
 import {
+  ForbiddenError,
+  Role,
+  type User,
+  withCurrentUser,
+} from '@repo/auth';
+import {
   Queue,
   QueueJobType,
   formatError,
   type TypedJob,
 } from '@repo/queue';
 import { Effect, Schema } from 'effect';
-import type { User } from '@repo/auth/policy';
 import {
   RunResultSchema,
   type CreateRunInput,
@@ -37,6 +42,8 @@ const CREATE_RUN_SOURCE_PATH =
   'packages/api/src/server/use-cases/runs.ts:createRunUseCase';
 const LIST_RUNS_SOURCE_PATH =
   'packages/api/src/server/use-cases/runs.ts:listRunsUseCase';
+const AUTHORIZATION_SOURCE_PATH =
+  'packages/api/src/server/use-cases/runs.ts:authorizeRunUseCaseUser';
 
 const toOptionalString = (value: unknown): string | null =>
   typeof value === 'string' && value.trim().length > 0 ? value : null;
@@ -86,6 +93,21 @@ const logRunResultDecodeFailure = (
     Effect.annotateLogs('parse.error.summary', parseErrorSummary),
   );
 
+const authorizeRunUseCaseUser = (user: User): Effect.Effect<void, ForbiddenError> =>
+  withCurrentUser(user)(
+    Effect.gen(function* () {
+      if (user.role !== Role.USER && user.role !== Role.ADMIN) {
+        return yield* Effect.fail(
+          new ForbiddenError({
+            message: 'Requires user or admin role',
+          }),
+        );
+      }
+
+      return;
+    }),
+  ).pipe(Effect.withSpan('runs.authorizeUser'));
+
 const toRunOutput = (
   job: RunJob,
   sourcePath: string,
@@ -128,6 +150,10 @@ const toRunOutput = (
 
 export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
   Effect.gen(function* () {
+    yield* authorizeRunUseCaseUser(user).pipe(
+      Effect.annotateLogs('source.path', AUTHORIZATION_SOURCE_PATH),
+    );
+
     const queue = yield* Queue;
     const publisher = yield* SSEPublisher;
 
@@ -159,6 +185,10 @@ export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
 
 export const listRunsUseCase = ({ user, input }: ListRunsUseCaseInput) =>
   Effect.gen(function* () {
+    yield* authorizeRunUseCaseUser(user).pipe(
+      Effect.annotateLogs('source.path', AUTHORIZATION_SOURCE_PATH),
+    );
+
     const queue = yield* Queue;
     const jobs = yield* queue.getJobsByUser(user.id, {
       type: QueueJobType.PROCESS_AI_RUN,

--- a/packages/testing/src/__tests__/effect-runner-boundaries.invariants.test.ts
+++ b/packages/testing/src/__tests__/effect-runner-boundaries.invariants.test.ts
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+type RunSyncViolation = {
+  filePath: string;
+  line: number;
+  column: number;
+  snippet: string;
+};
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, '..', '..', '..', '..');
+const sourceRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')];
+
+const SKIPPED_DIR_NAMES = new Set([
+  '.git',
+  '.turbo',
+  '.codex-worktrees',
+  'coverage',
+  'dist',
+  'build',
+  'node_modules',
+]);
+
+const RUNSYNC_ALLOWLIST = new Set([
+  'packages/api/src/server/index.ts',
+]);
+
+const toPosixPath = (value: string): string => value.split(path.sep).join('/');
+
+const toRelativePath = (filePath: string): string =>
+  toPosixPath(path.relative(repoRoot, filePath));
+
+const isRuntimeSourceFile = (filePath: string): boolean => {
+  const normalized = toPosixPath(filePath);
+
+  if (!/\.(ts|tsx)$/.test(normalized)) return false;
+  if (normalized.includes('/__tests__/')) return false;
+  if (normalized.includes('/testing/')) return false;
+  if (normalized.includes('/test-utils/')) return false;
+  if (/\.test\.[jt]sx?$/.test(normalized)) return false;
+  if (/\.spec\.[jt]sx?$/.test(normalized)) return false;
+
+  return true;
+};
+
+const collectRuntimeSourceFiles = (dirPath: string): string[] => {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const nextPath = path.join(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIR_NAMES.has(entry.name)) continue;
+      files.push(...collectRuntimeSourceFiles(nextPath));
+      continue;
+    }
+
+    if (entry.isFile() && isRuntimeSourceFile(nextPath)) {
+      files.push(nextPath);
+    }
+  }
+
+  return files;
+};
+
+const createViolation = (
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  node: ts.CallExpression,
+): RunSyncViolation => {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(sourceFile),
+  );
+
+  return {
+    filePath: toRelativePath(filePath),
+    line: line + 1,
+    column: character + 1,
+    snippet: node.getText(sourceFile).replace(/\s+/g, ' ').slice(0, 160),
+  };
+};
+
+const collectRunSyncViolations = (filePath: string): RunSyncViolation[] => {
+  const relativePath = toRelativePath(filePath);
+  if (RUNSYNC_ALLOWLIST.has(relativePath)) {
+    return [];
+  }
+
+  const sourceText = fs.readFileSync(filePath, 'utf-8');
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  const violations: RunSyncViolation[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === 'Effect' &&
+      node.expression.name.text === 'runSync'
+    ) {
+      violations.push(createViolation(sourceFile, filePath, node));
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+};
+
+const collectRepositoryViolations = (): RunSyncViolation[] =>
+  sourceRoots
+    .flatMap((root) => collectRuntimeSourceFiles(root))
+    .flatMap((filePath) => collectRunSyncViolations(filePath))
+    .sort((left, right) => {
+      const byPath = left.filePath.localeCompare(right.filePath);
+      if (byPath !== 0) return byPath;
+      if (left.line !== right.line) return left.line - right.line;
+      return left.column - right.column;
+    });
+
+const formatViolations = (violations: readonly RunSyncViolation[]): string =>
+  violations
+    .map(
+      (violation) =>
+        `${violation.filePath}:${violation.line}:${violation.column} disallowed Effect.runSync call\n  ${violation.snippet}`,
+    )
+    .join('\n');
+
+describe('effect runtime runner boundary invariants', () => {
+  it('forbids Effect.runSync in runtime internals outside explicit transport boundaries', () => {
+    const violations = collectRepositoryViolations();
+    expect(violations, formatViolations(violations)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce explicit authorization assertions in run use-cases before queue access
- convert worker completion/error callbacks to compositional `Effect` flows so non-boundary internals no longer call `Effect.runSync`
- add invariant coverage and docs that restrict `Effect.runSync` to explicit transport boundaries

Fixes #68
Fixes #69

## Aggregated Issues
- Fixes #68: enforced run use-case authorization invariant checks with typed forbidden-path tests
- Fixes #69: removed non-edge worker `Effect.runSync` calls, documented approved boundary, and added invariant guardrail coverage

## Workflow Routing
- #68 -> Feature Delivery workflow; companion skills: intake-triage, architecture-adr-guard, test-surface-steward
- #69 -> Architecture + ADR Guard workflow; companion skills: architecture-adr-guard, test-surface-steward

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build

## Research Log Update
- No research-trace/paper-linked issue in this bundle; `research/implemented-ideas.md` unchanged.
