### PR TITLE
feat: harden chat boundary, auth session failures, and fan-out concurrency

### DIFF
--- a/packages/ai/src/tts/use-cases/__tests__/list-voices-with-previews.test.ts
+++ b/packages/ai/src/tts/use-cases/__tests__/list-voices-with-previews.test.ts
@@ -3,7 +3,10 @@ import { Storage, type StorageService } from '@repo/storage';
 import { Effect, Layer } from 'effect';
 import { describe, expect } from 'vitest';
 import { TTS, type TTSService, VOICES } from '../../index';
-import { listVoicesWithPreviews } from '../list-voices-with-previews';
+import {
+  listVoicesWithPreviews,
+  PREVIEW_RESOLUTION_CONCURRENCY,
+} from '../list-voices-with-previews';
 
 // =============================================================================
 // Mock Services
@@ -29,6 +32,36 @@ const createMockStorageService = (
   exists: (key) => Effect.succeed(existingKeys.has(key)),
   getUrl: (key) => Effect.succeed(`https://storage.example.com/${key}`),
 });
+
+const createConcurrencyTrackingStorageService = (): {
+  service: StorageService;
+  getPeakConcurrency: () => number;
+} => {
+  let current = 0;
+  let peak = 0;
+
+  const service: StorageService = {
+    upload: () => Effect.die('Not implemented in mock'),
+    download: () => Effect.die('Not implemented in mock'),
+    delete: () => Effect.die('Not implemented in mock'),
+    exists: () =>
+      Effect.async<boolean, never>((resume) => {
+        current += 1;
+        peak = Math.max(peak, current);
+
+        setTimeout(() => {
+          current -= 1;
+          resume(Effect.succeed(false));
+        }, 5);
+      }),
+    getUrl: (key) => Effect.succeed(`https://storage.example.com/${key}`),
+  };
+
+  return {
+    service,
+    getPeakConcurrency: () => peak,
+  };
+};
 
 // =============================================================================
 // Tests
@@ -128,4 +161,25 @@ describe('listVoicesWithPreviews', () => {
       ),
     ),
   );
+
+  it.effect('keeps preview resolution bounded while preserving full output', () => {
+    const tracker = createConcurrencyTrackingStorageService();
+
+    return Effect.gen(function* () {
+      const result = yield* listVoicesWithPreviews({});
+
+      expect(result).toHaveLength(VOICES.length);
+      expect(result.every((voice) => voice.previewUrl === null)).toBe(true);
+      expect(tracker.getPeakConcurrency()).toBeLessThanOrEqual(
+        PREVIEW_RESOLUTION_CONCURRENCY,
+      );
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          Layer.succeed(TTS, createMockTTSService()),
+          Layer.succeed(Storage, tracker.service),
+        ),
+      ),
+    );
+  });
 });

--- a/packages/ai/src/tts/use-cases/list-voices-with-previews.ts
+++ b/packages/ai/src/tts/use-cases/list-voices-with-previews.ts
@@ -14,6 +14,9 @@ export interface VoiceWithPreview extends VoiceInfo {
   readonly previewUrl: string | null;
 }
 
+// Tune this if preview lookup throughput requirements change.
+export const PREVIEW_RESOLUTION_CONCURRENCY = 8;
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -45,6 +48,14 @@ export const listVoicesWithPreviews = (input: ListVoicesWithPreviewsInput) =>
     const tts = yield* TTS;
     const voices = yield* tts.listVoices({ gender: input.gender });
 
+    yield* Effect.logDebug('tts.listVoices.preview_resolution').pipe(
+      Effect.annotateLogs('tts.voice.count', voices.length),
+      Effect.annotateLogs(
+        'tts.preview.resolution.concurrency',
+        PREVIEW_RESOLUTION_CONCURRENCY,
+      ),
+    );
+
     return yield* Effect.all(
       voices.map((voice) =>
         resolvePreviewUrl(voice.id).pipe(
@@ -53,12 +64,14 @@ export const listVoicesWithPreviews = (input: ListVoicesWithPreviewsInput) =>
           ),
         ),
       ),
-      { concurrency: 'unbounded' },
+      { concurrency: PREVIEW_RESOLUTION_CONCURRENCY },
+    ).pipe(
+      Effect.withSpan('useCase.listVoicesWithPreviews', {
+        attributes: {
+          'filter.gender': input.gender,
+          'tts.voice.count': voices.length,
+          'tts.preview.resolution.concurrency': PREVIEW_RESOLUTION_CONCURRENCY,
+        },
+      }),
     );
-  }).pipe(
-    Effect.withSpan('useCase.listVoicesWithPreviews', {
-      attributes: {
-        'filter.gender': input.gender,
-      },
-    }),
-  );
+  });

--- a/packages/api/src/server/__tests__/router-handler.invariants.test.ts
+++ b/packages/api/src/server/__tests__/router-handler.invariants.test.ts
@@ -71,6 +71,18 @@ describe('router handler invariants', () => {
     }
   });
 
+  it('forbids unsafe UIMessage casts in routers', () => {
+    const forbidden = /as unknown as UIMessage\[\]/;
+
+    for (const file of listRouterHandlerFiles()) {
+      const source = readRouterSource(file);
+
+      if (forbidden.test(source)) {
+        throw new Error(`Router ${file} must not cast to UIMessage[] unsafely`);
+      }
+    }
+  });
+
   it('forbids @repo/db/schema imports in routers unless allowlisted', () => {
     const forbiddenImport = /from ['"]@repo\/db\/schema['"]/;
 

--- a/packages/api/src/server/router/__tests__/chat.behavior.test.ts
+++ b/packages/api/src/server/router/__tests__/chat.behavior.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { decodeChatContractMessages } from '../chat';
+
+describe('chat router message decoding', () => {
+  it('maps valid text-only contract messages to UI messages', () => {
+    const result = decodeChatContractMessages(
+      [
+        {
+          id: 'msg_1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello world' }],
+        },
+      ],
+      {},
+    );
+
+    expect(result).toEqual([
+      {
+        id: 'msg_1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello world' }],
+      },
+    ]);
+  });
+
+  it('throws INPUT_VALIDATION_FAILED for unsupported part types', () => {
+    const inputValidationError = vi.fn(() => new Error('unsupported-part'));
+
+    expect(() =>
+      decodeChatContractMessages(
+        [
+          {
+            id: 'msg_1',
+            role: 'user',
+            parts: [{ type: 'image', text: 'ignored' }],
+          },
+        ],
+        { INPUT_VALIDATION_FAILED: inputValidationError },
+      ),
+    ).toThrow('unsupported-part');
+
+    expect(inputValidationError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Unsupported chat message part type',
+        data: expect.objectContaining({
+          messageIndex: 0,
+          partIndex: 0,
+          partType: 'image',
+        }),
+      }),
+    );
+  });
+
+  it('throws INPUT_VALIDATION_FAILED when text part omits text payload', () => {
+    const inputValidationError = vi.fn(() => new Error('missing-text'));
+
+    expect(() =>
+      decodeChatContractMessages(
+        [
+          {
+            id: 'msg_1',
+            role: 'user',
+            parts: [{ type: 'text' }],
+          },
+        ],
+        { INPUT_VALIDATION_FAILED: inputValidationError },
+      ),
+    ).toThrow('missing-text');
+
+    expect(inputValidationError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Chat text message parts must include non-empty text',
+      }),
+    );
+  });
+});

--- a/packages/api/src/server/router/chat.ts
+++ b/packages/api/src/server/router/chat.ts
@@ -5,18 +5,93 @@ import {
 } from '../effect-handler';
 import { protectedProcedure } from '../orpc';
 
+interface ChatRouterErrorFactory {
+  INPUT_VALIDATION_FAILED?: (options: {
+    message: string;
+    data?: Record<string, unknown>;
+  }) => unknown;
+  INTERNAL_ERROR?: (options: {
+    message: string;
+    data?: Record<string, unknown>;
+  }) => unknown;
+}
+
+interface ChatContractMessagePart {
+  readonly type: string;
+  readonly text?: string;
+}
+
+interface ChatContractMessage {
+  readonly id: string;
+  readonly role: 'system' | 'user' | 'assistant';
+  readonly parts: readonly ChatContractMessagePart[];
+}
+
+const throwInputValidationError = (
+  errors: ChatRouterErrorFactory,
+  message: string,
+  data?: Record<string, unknown>,
+): never => {
+  const factory = errors.INPUT_VALIDATION_FAILED ?? errors.INTERNAL_ERROR;
+  if (factory) {
+    throw factory({ message, data });
+  }
+  throw new Error(message);
+};
+
+export const decodeChatContractMessages = (
+  messages: readonly ChatContractMessage[],
+  errors: ChatRouterErrorFactory,
+): UIMessage[] =>
+  messages.map((message, messageIndex) => ({
+    id: message.id,
+    role: message.role,
+    parts: message.parts.map((part, partIndex) => {
+      if (part.type !== 'text') {
+        return throwInputValidationError(
+          errors,
+          'Unsupported chat message part type',
+          {
+            messageIndex,
+            partIndex,
+            partType: part.type,
+          },
+        );
+      }
+
+      if (typeof part.text !== 'string' || part.text.length === 0) {
+        return throwInputValidationError(
+          errors,
+          'Chat text message parts must include non-empty text',
+          {
+            messageIndex,
+            partIndex,
+          },
+        );
+      }
+
+      return {
+        type: 'text' as const,
+        text: part.text,
+      };
+    }),
+  }));
+
 const chatRouter = {
   general: protectedProcedure.chat.general.handler(
-    async ({ context, input, errors }) =>
-      handleEffectStreamWithProtocol(
+    async ({ context, input, errors }) => {
+      const messages = decodeChatContractMessages(input.messages, errors);
+
+      return handleEffectStreamWithProtocol(
         context.runtime,
         context.user,
         streamGeneralChat({
-          messages: input.messages as unknown as UIMessage[],
+          messages,
         }),
         errors,
         { requestId: context.requestId, span: 'api.chat.general' },
-      ),
+      );
+    },
   ),
 };
 

--- a/packages/auth/src/__tests__/session.test.ts
+++ b/packages/auth/src/__tests__/session.test.ts
@@ -59,9 +59,16 @@ describe('getSession', () => {
     } as unknown as AuthInstance;
     const headers = new Headers();
 
-    const result = await Effect.runPromise(getSession(auth, headers));
+    const exit = await Effect.runPromiseExit(getSession(auth, headers));
 
-    expect(result).toBeNull();
+    expect(exit._tag).toBe('Failure');
+    if (exit._tag === 'Failure') {
+      const failure = exit.cause;
+      expect(failure._tag).toBe('Fail');
+      if (failure._tag === 'Fail') {
+        expect(failure.error._tag).toBe('AuthSessionError');
+      }
+    }
   });
 });
 

--- a/packages/auth/src/errors.ts
+++ b/packages/auth/src/errors.ts
@@ -15,3 +15,16 @@ export class PolicyError extends Schema.TaggedError<PolicyError>()(
   static readonly httpMessage = 'Authorization check failed';
   static readonly logLevel = 'error-with-stack' as const;
 }
+
+export class AuthSessionError extends Schema.TaggedError<AuthSessionError>()(
+  'AuthSessionError',
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Unknown),
+  },
+) {
+  static readonly httpStatus = 502 as const;
+  static readonly httpCode = 'SERVICE_UNAVAILABLE' as const;
+  static readonly httpMessage = 'Authentication service is unavailable';
+  static readonly logLevel = 'warn' as const;
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -31,4 +31,9 @@ export {
 } from './policy';
 
 // Re-export errors
-export { UnauthorizedError, ForbiddenError, PolicyError } from './errors';
+export {
+  UnauthorizedError,
+  ForbiddenError,
+  PolicyError,
+  AuthSessionError,
+} from './errors';

--- a/packages/auth/src/server/session.ts
+++ b/packages/auth/src/server/session.ts
@@ -1,8 +1,11 @@
 import { Effect } from 'effect';
 import type { AuthInstance } from './auth';
-import type { PolicyError } from '../errors';
 import type { User } from '../policy/types';
-import { UnauthorizedError } from '../errors';
+import {
+  AuthSessionError,
+  type PolicyError,
+  UnauthorizedError,
+} from '../errors';
 import { Policy } from '../policy/service';
 
 type Session = AuthInstance['$Infer']['Session'];
@@ -14,13 +17,21 @@ type Session = AuthInstance['$Infer']['Session'];
 export const getSession = (
   auth: AuthInstance,
   headers: Headers,
-): Effect.Effect<Session | null> =>
+): Effect.Effect<Session | null, AuthSessionError> =>
   Effect.tryPromise({
     try: () => auth.api.getSession({ headers }),
-    catch: (error) => error,
+    catch: (cause) =>
+      new AuthSessionError({
+        message: 'Failed to retrieve authentication session',
+        cause,
+      }),
   }).pipe(
     Effect.map((s) => s ?? null),
-    Effect.catchAll(() => Effect.succeed(null)),
+    Effect.tapError((error) =>
+      Effect.logWarning('auth.getSession.failed').pipe(
+        Effect.annotateLogs('auth.failure.tag', error._tag),
+      ),
+    ),
     Effect.withSpan('auth.getSession'),
   );
 
@@ -33,7 +44,7 @@ export const getSessionWithRole = (
   headers: Headers,
 ): Effect.Effect<
   { session: Session; user: User } | null,
-  PolicyError,
+  PolicyError | AuthSessionError,
   Policy
 > =>
   Effect.gen(function* () {
@@ -62,7 +73,7 @@ export const requireSession = (
   headers: Headers,
 ): Effect.Effect<
   { session: Session; user: User },
-  UnauthorizedError | PolicyError,
+  UnauthorizedError | PolicyError | AuthSessionError,
   Policy
 > =>
   getSessionWithRole(auth, headers).pipe(

--- a/packages/db/src/__tests__/serialization.test.ts
+++ b/packages/db/src/__tests__/serialization.test.ts
@@ -75,6 +75,20 @@ describe('createBatchEffectSerializer', () => {
     const results = await Effect.runPromise(serializeBatch([]));
     expect(results).toEqual([]);
   });
+
+  it('serializes full output correctly for batches larger than concurrency cap', async () => {
+    const entities: TestEntity[] = Array.from({ length: 64 }, (_, index) => ({
+      id: `entity_${index}`,
+      name: `Entity ${index}`,
+      createdAt: new Date(`2024-01-${String((index % 28) + 1).padStart(2, '0')}`),
+    }));
+
+    const results = await Effect.runPromise(serializeBatch(entities));
+
+    expect(results).toHaveLength(64);
+    expect(results[0]!.id).toBe('entity_0');
+    expect(results[63]!.id).toBe('entity_63');
+  });
 });
 
 describe('createSyncSerializer', () => {

--- a/packages/db/src/schemas/serialization.ts
+++ b/packages/db/src/schemas/serialization.ts
@@ -41,16 +41,21 @@ export const createBatchEffectSerializer = <DbType, OutputType>(
   entityName: string,
   transform: (entity: DbType) => OutputType,
 ) => {
+  // Tune this if serialization throughput requirements change.
+  const SERIALIZATION_CONCURRENCY = 32;
   const serialize = createEffectSerializer(entityName, transform);
 
   return (
     entities: readonly DbType[],
   ): Effect.Effect<OutputType[], SerializationError> =>
-    Effect.all(entities.map(serialize), { concurrency: 'unbounded' }).pipe(
+    Effect.all(entities.map(serialize), {
+      concurrency: SERIALIZATION_CONCURRENCY,
+    }).pipe(
       Effect.withSpan(`serialize.${entityName}.batch`, {
         attributes: {
           'serialization.entity': entityName,
           'serialization.count': entities.length,
+          'serialization.concurrency': SERIALIZATION_CONCURRENCY,
         },
       }),
     );


### PR DESCRIPTION
Fixes #59
Fixes #60
Fixes #61

## Aggregated Issues
- Fixes #59 - Replace unsafe chat UIMessage cast with validated boundary mapper
- Fixes #60 - Bound unbounded Effect.all concurrency in production fan-out paths
- Fixes #61 - Stop silent auth session failure collapse into null

## Workflow Routing
- #59 -> Feature Delivery (companions: intake-triage, test-surface-steward)
- #60 -> Feature Delivery (companions: intake-triage, test-surface-steward)
- #61 -> Feature Delivery (companions: intake-triage, test-surface-steward)

## What Changed
- Added explicit chat contract-to-UI message decoding with validation failures mapped to protocol input-validation errors.
- Added router invariant and behavior tests to prevent unsafe UIMessage cast regressions.
- Replaced unbounded fan-out with explicit concurrency defaults in TTS preview lookup and DB batch serialization; added concurrency observability fields and targeted tests.
- Changed auth session retrieval to surface typed AuthSessionError and structured warning telemetry for unexpected provider/runtime failures while preserving null for expected no-session.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build

## Research Log Update
- Not applicable (no issue in this bundle included a Research Trace requirement).
