### PR TITLE
feat(web): expose dashboard run-load recovery

### DIFF
--- a/apps/web/src/pages/dashboard.test.tsx
+++ b/apps/web/src/pages/dashboard.test.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { DashboardPage } from './dashboard';
+
+const { listRunsMock } = vi.hoisted(() => ({
+  listRunsMock: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    ...props
+  }: {
+    children: ReactNode;
+    to: string;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/clients/api-client', () => ({
+  rawApiClient: {
+    runs: {
+      list: listRunsMock,
+    },
+  },
+}));
+
+vi.mock('@/clients/auth-client', () => ({
+  authClient: {
+    useSession: () => ({ data: { user: { id: 'user-1' } } }),
+  },
+}));
+
+vi.mock('@/lib/chat-utils', () => ({
+  loadThreads: () => [],
+}));
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    listRunsMock.mockReset();
+  });
+
+  it('shows an explicit runs load failure and recovers on retry', async () => {
+    listRunsMock
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockResolvedValueOnce([
+        {
+          id: 'run-1',
+          status: 'pending',
+          prompt: 'First run',
+          threadId: null,
+          result: null,
+          error: null,
+          createdAt: '2026-02-26T00:00:00.000Z',
+          updatedAt: '2026-02-26T00:00:00.000Z',
+          startedAt: null,
+          completedAt: null,
+        },
+      ]);
+
+    render(<DashboardPage />);
+
+    expect(await screen.findByText('Runs failed to load.')).toBeInTheDocument();
+    expect(screen.getByText('Unable to load recent runs.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry loading runs' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading runs' }));
+
+    await waitFor(() => {
+      expect(listRunsMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(await screen.findByText('First run')).toBeInTheDocument();
+    expect(screen.queryByText('Runs failed to load.')).not.toBeInTheDocument();
+    expect(screen.getByText(/Last updated/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,7 +1,8 @@
 import { Badge } from '@repo/ui/components/badge';
+import { Button } from '@repo/ui/components/button';
 import { Spinner } from '@repo/ui/components/spinner';
 import { Link } from '@tanstack/react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { rawApiClient } from '@/clients/api-client';
 import { authClient } from '@/clients/auth-client';
 import { EngineIcon } from '@/components/logo';
@@ -9,6 +10,7 @@ import { loadThreads } from '@/lib/chat-utils';
 import {
   type RunState,
   formatRunStatus,
+  readErrorMessage,
   formatTimestamp,
   sortRuns,
   toRunState,
@@ -111,19 +113,32 @@ export function DashboardPage() {
   const { data: session } = authClient.useSession();
   const [runs, setRuns] = useState<RunState[]>([]);
   const [runsLoading, setRunsLoading] = useState(true);
+  const [runsLoadError, setRunsLoadError] = useState<string | null>(null);
+  const [lastRunsUpdatedAt, setLastRunsUpdatedAt] = useState<string | null>(null);
+
+  const loadRuns = useCallback(async () => {
+    setRunsLoading(true);
+    setRunsLoadError(null);
+    try {
+      const result = await rawApiClient.runs.list({ limit: 10 });
+      setRuns(result.map(toRunState).sort(sortRuns));
+      setLastRunsUpdatedAt(new Date().toISOString());
+    } catch (error) {
+      setRunsLoadError(readErrorMessage(error, 'Failed to load runs.'));
+    } finally {
+      setRunsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
 
     const load = async () => {
-      try {
-        const result = await rawApiClient.runs.list({ limit: 10 });
-        if (!cancelled) setRuns(result.map(toRunState).sort(sortRuns));
-      } catch {
-        /* ignore initial load errors */
-      } finally {
-        if (!cancelled) setRunsLoading(false);
+      if (cancelled) {
+        return;
       }
+
+      await loadRuns();
     };
 
     void load();
@@ -131,7 +146,7 @@ export function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadRuns]);
 
   const threadCount = useMemo(() => {
     if (!session?.user) return 0;
@@ -146,6 +161,11 @@ export function DashboardPage() {
     const failed = runs.filter((r) => r.status === 'failed').length;
     return { active, completed, failed };
   }, [runs]);
+
+  const runsStatsUnavailable = runsLoadError !== null;
+  const activeRunsValue = runsStatsUnavailable ? '—' : String(stats.active);
+  const completedRunsValue = runsStatsUnavailable ? '—' : String(stats.completed);
+  const failedRunsValue = runsStatsUnavailable ? '—' : String(stats.failed);
 
   return (
     <div className="page-container animate-fade-in">
@@ -176,7 +196,7 @@ export function DashboardPage() {
               <ActivityIcon />
             </div>
           </div>
-          <p className="stat-card-value">{stats.active}</p>
+          <p className="stat-card-value">{activeRunsValue}</p>
         </div>
         <div className="stat-card animate-fade-in stagger-3">
           <div className="stat-card-header">
@@ -185,7 +205,7 @@ export function DashboardPage() {
               <CheckIcon />
             </div>
           </div>
-          <p className="stat-card-value">{stats.completed}</p>
+          <p className="stat-card-value">{completedRunsValue}</p>
         </div>
         <div className="stat-card animate-fade-in stagger-4">
           <div className="stat-card-header">
@@ -194,9 +214,31 @@ export function DashboardPage() {
               <AlertIcon />
             </div>
           </div>
-          <p className="stat-card-value">{stats.failed}</p>
+          <p className="stat-card-value">{failedRunsValue}</p>
         </div>
       </div>
+
+      {runsLoadError ? (
+        <div className="card-padded mb-8 border-destructive/30 bg-destructive/5 text-destructive">
+          <p className="section-title text-destructive">Runs failed to load.</p>
+          <p className="mt-2 text-sm">{runsLoadError}</p>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void loadRuns()}
+              disabled={runsLoading}
+            >
+              {runsLoading ? 'Retrying...' : 'Retry loading runs'}
+            </Button>
+            {lastRunsUpdatedAt ? (
+              <span className="text-xs text-muted-foreground">
+                Last updated {formatTimestamp(lastRunsUpdatedAt)}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
 
       {/* Quick Actions */}
       <div className="section-header">
@@ -234,6 +276,11 @@ export function DashboardPage() {
             <h3>Recent Runs</h3>
             <span className="recent-section-count">{runs.length}</span>
           </div>
+          {lastRunsUpdatedAt ? (
+            <span className="text-xs text-muted-foreground">
+              Last updated {formatTimestamp(lastRunsUpdatedAt)}
+            </span>
+          ) : null}
           <Link to="/jobs" className="text-link">
             View all
           </Link>
@@ -242,6 +289,16 @@ export function DashboardPage() {
         {runsLoading ? (
           <div className="loading-center">
             <Spinner size="sm" />
+          </div>
+        ) : runsLoadError ? (
+          <div className="recent-section-empty">
+            <div className="empty-state-icon mb-3">
+              <AlertIcon />
+            </div>
+            <p className="text-sm text-destructive">Unable to load recent runs.</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Retry to refresh dashboard run data.
+            </p>
           </div>
         ) : runs.length === 0 ? (
           <div className="recent-section-empty">


### PR DESCRIPTION
Fixes #51

## Summary
- expose a visible dashboard runs-load failure state instead of silently swallowing `runs.list` errors
- add retry action that reloads run data in place without full-page refresh
- track and display last successful update context to avoid ambiguous stale/empty interpretation
- add web RTL coverage for failed load -> retry -> success

## Aggregated Issues
- Fixes #51 (fully resolved)

## Workflow Routing
- #51 -> Feature Delivery (skills: feature-delivery, intake-triage, tanstack-vite)

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Not applicable (no Research Trace / external-paper implementation requirement on this issue)
