### PR TITLE
feat: idempotent run creation and resilient SSE publish

### DIFF
--- a/packages/api/src/contracts/runs.ts
+++ b/packages/api/src/contracts/runs.ts
@@ -35,6 +35,13 @@ const CreateRunInputSchema = Schema.Struct({
     Schema.minLength(1),
     Schema.maxLength(4000),
   ),
+  idempotencyKey: Schema.optional(
+    Schema.String.pipe(
+      Schema.trimmed(),
+      Schema.minLength(1),
+      Schema.maxLength(128),
+    ),
+  ),
   threadId: Schema.optional(
     Schema.String.pipe(Schema.trimmed(), Schema.maxLength(128)),
   ),

--- a/packages/api/src/server/router/__tests__/runs.behavior.test.ts
+++ b/packages/api/src/server/router/__tests__/runs.behavior.test.ts
@@ -244,14 +244,16 @@ describe('runs router behavior', () => {
       let enqueueType: string | undefined;
       let enqueuePayload: unknown;
       let enqueueUserId: string | undefined;
+      let enqueueOptions: Parameters<QueueService['enqueue']>[3] | undefined;
 
       const queue = createMockQueueService({
         getJobsByUser: (() =>
           Effect.succeed([])) as QueueService['getJobsByUser'],
-        enqueue: ((type, payload, userId) => {
+        enqueue: ((type, payload, userId, options) => {
           enqueueType = type;
           enqueuePayload = payload;
           enqueueUserId = userId;
+          enqueueOptions = options;
 
           return Effect.succeed(
             createJob({ payload: payload as RunPayload }),
@@ -269,7 +271,7 @@ describe('runs router behavior', () => {
       );
 
       const created = await invokeProcedure<
-        { prompt: string; threadId?: string | null },
+        { prompt: string; idempotencyKey?: string; threadId?: string | null },
         Awaited<ReturnType<typeof runsRouter.create['~orpc']['handler']>>
       >({
         procedure: runsRouter.create,
@@ -277,6 +279,7 @@ describe('runs router behavior', () => {
         context: createMockContext(runtime, TEST_USER),
         input: {
           prompt: 'Plan quarterly roadmap',
+          idempotencyKey: 'idempotency-key-123',
           threadId: 'thread_123',
         },
       });
@@ -288,17 +291,20 @@ describe('runs router behavior', () => {
         userId: TEST_USER.id,
         idempotencyKey: expect.any(String),
       });
+      expect(enqueueOptions).toEqual({ idempotencyKey: 'idempotency-key-123' });
       expect(enqueueUserId).toBe(TEST_USER.id);
-      expect(publish).toHaveBeenCalledTimes(1);
-      expect(publish).toHaveBeenCalledWith(
-        TEST_USER.id,
-        expect.objectContaining({
-          type: 'run_queued',
-          runId: 'job_test',
-          prompt: 'Plan quarterly roadmap',
-          threadId: 'thread_123',
-        }),
-      );
+      await vi.waitFor(() => {
+        expect(publish).toHaveBeenCalledTimes(1);
+        expect(publish).toHaveBeenCalledWith(
+          TEST_USER.id,
+          expect.objectContaining({
+            type: 'run_queued',
+            runId: 'job_test',
+            prompt: 'Plan quarterly roadmap',
+            threadId: 'thread_123',
+          }),
+        );
+      });
       expect(created).toEqual({
         id: 'job_test',
         status: 'pending',
@@ -329,7 +335,7 @@ describe('runs router behavior', () => {
       );
 
       const error = await invokeProcedure<
-        { prompt: string; threadId?: string | null },
+        { prompt: string; idempotencyKey?: string; threadId?: string | null },
         never
       >({
         procedure: runsRouter.create,
@@ -347,12 +353,50 @@ describe('runs router behavior', () => {
       });
     });
 
+    it('returns success when queued-event publish fails after enqueue', async () => {
+      const runtime = createRuntime(
+        createMockQueueService({
+          enqueue: ((type, payload, userId) =>
+            Effect.succeed(
+              createJob({
+                type,
+                payload: payload as RunPayload,
+                createdBy: userId,
+              }),
+            )) as QueueService['enqueue'],
+        }),
+        createMockPublisherService({
+          publish: () => Effect.fail(new Error('sse unavailable')),
+        }),
+      );
+
+      const created = await invokeProcedure<
+        { prompt: string; idempotencyKey?: string; threadId?: string | null },
+        Awaited<ReturnType<typeof runsRouter.create['~orpc']['handler']>>
+      >({
+        procedure: runsRouter.create,
+        path: ['runs', 'create'],
+        context: createMockContext(runtime, TEST_USER),
+        input: {
+          prompt: 'Plan quarterly roadmap',
+          idempotencyKey: 'idempotency-key-123',
+        },
+      });
+
+      expect(created.id).toBe('job_test');
+      expect(created.prompt).toBe('Plan quarterly roadmap');
+      await expectMatchesContractOutput(
+        runsContract.create as unknown as ProcedureWithOutputSchema,
+        created,
+      );
+    });
+
     it('rejects unauthenticated context before handler execution', async () => {
       const runtime = createRuntime(createMockQueueService());
 
       try {
         await invokeProcedure<
-          { prompt: string; threadId?: string | null },
+          { prompt: string; idempotencyKey?: string; threadId?: string | null },
           never
         >({
           procedure: runsRouter.create,

--- a/packages/api/src/server/sse-publisher-service.ts
+++ b/packages/api/src/server/sse-publisher-service.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer } from 'effect';
+import { Context, Effect, Layer, Schedule } from 'effect';
 import type { SSEEvent } from '../contracts/events';
 import { ssePublisher } from './publisher';
 
@@ -6,7 +6,7 @@ export interface SSEPublisherService {
   readonly publish: (
     userId: string,
     event: SSEEvent,
-  ) => Effect.Effect<void, never>;
+  ) => Effect.Effect<void, Error>;
 }
 
 export class SSEPublisher extends Context.Tag('@repo/api/SSEPublisher')<
@@ -16,7 +16,27 @@ export class SSEPublisher extends Context.Tag('@repo/api/SSEPublisher')<
 
 export const SSEPublisherLive = Layer.succeed(SSEPublisher, {
   publish: (userId, event) =>
-    Effect.sync(() => {
-      ssePublisher.publish(userId, event);
-    }),
+    Effect.try({
+      try: () => {
+        ssePublisher.publish(userId, event);
+      },
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(String(cause)),
+    }).pipe(
+      Effect.tapError((error) =>
+        Effect.logWarning('sse.publish.retry').pipe(
+          Effect.annotateLogs('sse.user.id', userId),
+          Effect.annotateLogs('sse.event.type', event.type),
+          Effect.annotateLogs('sse.error.message', error.message),
+        ),
+      ),
+      Effect.retry(Schedule.recurs(2)),
+      Effect.tapError((error) =>
+        Effect.logWarning('sse.publish.failed').pipe(
+          Effect.annotateLogs('sse.user.id', userId),
+          Effect.annotateLogs('sse.event.type', event.type),
+          Effect.annotateLogs('sse.error.message', error.message),
+        ),
+      ),
+    ),
 });

--- a/packages/api/src/server/use-cases/__tests__/runs.test.ts
+++ b/packages/api/src/server/use-cases/__tests__/runs.test.ts
@@ -93,14 +93,16 @@ describe('runs use-cases', () => {
     let enqueueType: string | undefined;
     let enqueuePayload: unknown;
     let enqueueUserId: string | undefined;
+    let enqueueOptions: Parameters<QueueService['enqueue']>[3] | undefined;
 
     const queue = createMockQueueService({
       getJobsByUser: (() =>
         Effect.succeed([])) as QueueService['getJobsByUser'],
-      enqueue: ((type, payload, userId) => {
+      enqueue: ((type, payload, userId, options) => {
         enqueueType = type;
         enqueuePayload = payload;
         enqueueUserId = userId;
+        enqueueOptions = options;
         return Effect.succeed(
           createJob({ payload: payload as RunPayload }),
         ) as ReturnType<QueueService['enqueue']>;
@@ -117,6 +119,7 @@ describe('runs use-cases', () => {
         user: TEST_USER,
         input: {
           prompt: 'Plan quarterly roadmap',
+          idempotencyKey: 'idempotency-key-123',
           threadId: 'thread_123',
         },
       }).pipe(withQueueAndPublisher(queue, publisher)),
@@ -130,16 +133,19 @@ describe('runs use-cases', () => {
       userId: TEST_USER.id,
       idempotencyKey: expect.any(String),
     });
-    expect(publish).toHaveBeenCalledTimes(1);
-    expect(publish).toHaveBeenCalledWith(
-      TEST_USER.id,
-      expect.objectContaining({
-        type: 'run_queued',
-        runId: 'job_test',
-        prompt: 'Plan quarterly roadmap',
-        threadId: 'thread_123',
-      }),
-    );
+    expect(enqueueOptions).toEqual({ idempotencyKey: 'idempotency-key-123' });
+    await vi.waitFor(() => {
+      expect(publish).toHaveBeenCalledTimes(1);
+      expect(publish).toHaveBeenCalledWith(
+        TEST_USER.id,
+        expect.objectContaining({
+          type: 'run_queued',
+          runId: 'job_test',
+          prompt: 'Plan quarterly roadmap',
+          threadId: 'thread_123',
+        }),
+      );
+    });
     expect(result.prompt).toBe('Plan quarterly roadmap');
     expect(result.threadId).toBe('thread_123');
   });
@@ -165,6 +171,32 @@ describe('runs use-cases', () => {
 
     expect(error._tag).toBe('QueueError');
     expect(error.message).toBe('queue unavailable');
+  });
+
+  it('returns success when queued-event publish fails after enqueue', async () => {
+    const queue = createMockQueueService({
+      enqueue: ((type, payload, userId) =>
+        Effect.succeed(
+          createJob({ type, payload: payload as RunPayload, createdBy: userId }),
+        )) as QueueService['enqueue'],
+    });
+
+    const publisher = createMockPublisherService({
+      publish: () => Effect.fail(new Error('sse unavailable')),
+    });
+
+    const result = await Effect.runPromise(
+      createRunUseCase({
+        user: TEST_USER,
+        input: {
+          prompt: 'Plan quarterly roadmap',
+          idempotencyKey: 'retry-key-1',
+        },
+      }).pipe(withQueueAndPublisher(queue, publisher)),
+    );
+
+    expect(result.id).toBe('job_test');
+    expect(result.prompt).toBe('Plan quarterly roadmap');
   });
 
   it('fails create run with typed forbidden error for unauthorized roles', async () => {

--- a/packages/api/src/server/use-cases/runs.ts
+++ b/packages/api/src/server/use-cases/runs.ts
@@ -309,6 +309,9 @@ export const createRunUseCase = ({ user, input }: CreateRunUseCaseInput) =>
         idempotencyKey,
       },
       user.id,
+      {
+        idempotencyKey: input.idempotencyKey,
+      },
     );
 
     const run = yield* toRunOutput(

--- a/packages/db/drizzle/0002_spooky_wallop.sql
+++ b/packages/db/drizzle/0002_spooky_wallop.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "job" ADD COLUMN "idempotencyKey" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "job_createdBy_type_idempotencyKey_unique" ON "job" USING btree ("createdBy","type","idempotencyKey") WHERE "job"."idempotencyKey" IS NOT NULL;

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,602 @@
+{
+  "id": "937d4426-c6dd-4bcc-87a4-36ddf6172183",
+  "prevId": "a26e43d6-abe1-4284-b661-3991d8a5f198",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job": {
+      "name": "job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_createdBy_idx": {
+          "name": "job_createdBy_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_createdBy_type_createdAt_idx": {
+          "name": "job_createdBy_type_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_createdBy_type_idempotencyKey_unique": {
+          "name": "job_createdBy_type_idempotencyKey_unique",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"job\".\"idempotencyKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_type_status_idx": {
+          "name": "job_type_status_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_createdBy_user_id_fk": {
+          "name": "job_createdBy_user_id_fk",
+          "tableFrom": "job",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771879161707,
       "tag": "0001_rich_falcon",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772089761353,
+      "tag": "0002_spooky_wallop",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/job-schema.test.ts
+++ b/packages/db/src/__tests__/job-schema.test.ts
@@ -58,6 +58,7 @@ describe('jobs schema', () => {
         nextActions: ['N'],
       },
       error: null,
+      idempotencyKey: null,
       createdBy: 'user_1',
       createdAt: now,
       updatedAt: now,

--- a/packages/db/src/schemas/jobs.ts
+++ b/packages/db/src/schemas/jobs.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
   pgTable,
   text,
@@ -5,6 +6,7 @@ import {
   varchar,
   jsonb,
   index,
+  uniqueIndex,
   pgEnum,
 } from 'drizzle-orm/pg-core';
 import { Schema } from 'effect';
@@ -34,6 +36,7 @@ export const job = pgTable(
     payload: jsonb('payload').$type<Record<string, unknown>>().notNull(),
     result: jsonb('result').$type<Record<string, unknown>>(),
     error: text('error'),
+    idempotencyKey: text('idempotencyKey'),
     createdBy: text('createdBy')
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
@@ -56,6 +59,9 @@ export const job = pgTable(
       table.type,
       table.createdAt,
     ),
+    uniqueIndex('job_createdBy_type_idempotencyKey_unique')
+      .on(table.createdBy, table.type, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
     index('job_status_idx').on(table.status),
     index('job_type_status_idx').on(table.type, table.status),
   ],
@@ -112,6 +118,7 @@ export interface JobSerializable {
   readonly status: JobStatus;
   readonly result: unknown;
   readonly error: string | null;
+  readonly idempotencyKey: string | null;
   readonly createdBy: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;

--- a/packages/queue/src/__tests__/claim-job.integration.test.ts
+++ b/packages/queue/src/__tests__/claim-job.integration.test.ts
@@ -96,6 +96,39 @@ describe.skipIf(!POSTGRES_URL)('Queue atomic job claim (integration)', () => {
     expect(result!.status).toBe(JobStatus.COMPLETED);
   });
 
+  it('deduplicates enqueue when idempotency key is reused', async () => {
+    const first = await runEffect(
+      Effect.flatMap(Queue, (q) =>
+        q.enqueue(
+          JobType.PROCESS_AI_RUN,
+          { prompt: 'same request', userId: testUserId },
+          testUserId,
+          { idempotencyKey: 'run-create-retry-1' },
+        ),
+      ),
+    );
+
+    const second = await runEffect(
+      Effect.flatMap(Queue, (q) =>
+        q.enqueue(
+          JobType.PROCESS_AI_RUN,
+          { prompt: 'same request', userId: testUserId },
+          testUserId,
+          { idempotencyKey: 'run-create-retry-1' },
+        ),
+      ),
+    );
+
+    const rows = await db
+      .select()
+      .from(job)
+      .where(eq(job.createdBy, testUserId));
+
+    expect(first.id).toBe(second.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(first.id);
+  });
+
   it('returns null when no pending jobs exist', async () => {
     const result = await runEffect(
       Effect.flatMap(Queue, (q) =>

--- a/packages/queue/src/repository.ts
+++ b/packages/queue/src/repository.ts
@@ -93,22 +93,69 @@ const makeQueueService = Effect.gen(function* () {
     type: TType,
     payload: JobPayload<TType>,
     userId: string,
+    options?: { readonly idempotencyKey?: string | null },
   ): Effect.Effect<TypedJob<TType>, QueueError> =>
     runQuery(
       'enqueue',
       async (db) => {
-        const [row] = await db
+        const trimmedIdempotencyKey = options?.idempotencyKey?.trim();
+        const idempotencyKey =
+          trimmedIdempotencyKey && trimmedIdempotencyKey.length > 0
+            ? trimmedIdempotencyKey
+            : null;
+
+        if (!idempotencyKey) {
+          const [row] = await db
+            .insert(job)
+            .values({
+              type,
+              payload: payload as unknown as Record<string, unknown>,
+              createdBy: userId,
+              idempotencyKey: null,
+            })
+            .returning();
+
+          if (!row) throw new Error('Failed to insert job');
+
+          return mapRowToJob<TType>(row);
+        }
+
+        const [inserted] = await db
           .insert(job)
           .values({
             type,
             payload: payload as unknown as Record<string, unknown>,
             createdBy: userId,
+            idempotencyKey,
+          })
+          .onConflictDoNothing({
+            target: [job.createdBy, job.type, job.idempotencyKey],
           })
           .returning();
 
-        if (!row) throw new Error('Failed to insert job');
+        if (inserted) {
+          return mapRowToJob<TType>(inserted);
+        }
 
-        return mapRowToJob<TType>(row);
+        const [existing] = await db
+          .select()
+          .from(job)
+          .where(
+            and(
+              eq(job.createdBy, userId),
+              eq(job.type, type),
+              eq(job.idempotencyKey, idempotencyKey),
+            ),
+          )
+          .limit(1);
+
+        if (!existing) {
+          throw new Error(
+            'Failed to resolve idempotent enqueue after conflict',
+          );
+        }
+
+        return mapRowToJob<TType>(existing);
       },
       'Failed to enqueue job',
     ).pipe(
@@ -117,6 +164,7 @@ const makeQueueService = Effect.gen(function* () {
           'queue.job.id': j.id,
           'queue.job.type': type,
           'queue.user.id': userId,
+          'queue.job.idempotency_key': options?.idempotencyKey ?? 'none',
         }),
       ),
     );

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -16,11 +16,16 @@ import type {
 import type { JobId } from '@repo/db/schema';
 import type { Effect } from 'effect';
 
+export interface EnqueueOptions {
+  readonly idempotencyKey?: string | null;
+}
+
 export interface QueueService {
   readonly enqueue: <TType extends JobType>(
     type: TType,
     payload: JobPayload<TType>,
     userId: string,
+    options?: EnqueueOptions,
   ) => Effect.Effect<TypedJob<TType>, QueueError>;
 
   readonly getJob: (


### PR DESCRIPTION
Fixes #67

## Summary
- add optional `idempotencyKey` to runs.create contract and thread it through `createRunUseCase`
- add queue-level idempotent enqueue options backed by a new `job.idempotencyKey` column and unique partial index
- switch run-queued publish behavior to asynchronous best-effort with retry/failure telemetry so durable enqueue success is returned even if publish fails
- extend backend tests for idempotent duplicate retries and publish-failure resilience

## Aggregated Issues
- Fixes #67 (fully resolved)

## Workflow Routing
- #67 -> Feature Delivery workflow
  - Skills: `feature-delivery`
  - Rationale: backend reliability feature change across contract/use-case/repository/test surfaces with no ADR-level boundary deviation

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Not applicable (no Research Trace/external paper adoption in this implementation issue)
