### PR TITLE
fix(ai): resolve duplicate weather tool export

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -125,7 +125,7 @@ export {
 
 // Tools
 export {
-  invokeWeatherTool,
+  invokeWeatherTool as invokeWeatherToolDirect,
   WEATHER_PROVIDER_HOST,
   WEATHER_TOOL_CONTRACT_VERSION,
   WEATHER_TOOL_ID,


### PR DESCRIPTION
Refs #46

## Summary
- resolve duplicate `invokeWeatherTool` export in `packages/ai/src/index.ts`

## Validation
- pnpm --filter @repo/ai run typecheck
