### PR TITLE
feat: standardize automation label bootstrap and memory fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: pnpm typecheck
 
       - name: Lint
+        # Root lint script already runs `pnpm scripts:lint` first, then package lint tasks.
+        # Keep this as the single scripts-lint execution path in CI.
         run: pnpm lint
 
       - name: Test
@@ -52,6 +54,3 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-      - name: Scripts Lint
-        run: pnpm scripts:lint

--- a/agent-engine/automations/README.md
+++ b/agent-engine/automations/README.md
@@ -91,6 +91,12 @@ For every lane:
 - The `.toml` wrapper should only load and execute that playbook.
 - If wrapper and playbook conflict, follow the playbook.
 
+## Required Automation Label Bootstrap
+
+Automation lanes that create issues or PRs must ensure required labels exist in-repo before issue operations. At minimum, bootstrap:
+
+- `gh label create codex-automation --color 5319E7 --description "Issue or PR created by Codex automation" --force`
+
 ## Required Contract For Any Code-Writing Automation
 
 Any automation that edits code must:

--- a/agent-engine/automations/agent-engine-researcher/agent-engine-researcher.md
+++ b/agent-engine/automations/agent-engine-researcher/agent-engine-researcher.md
@@ -67,6 +67,7 @@ Research protocol:
 Issue policy:
 - Ensure label availability before issue operations:
   - `gh label create agent-engine-researcher --color 1D76DB --description "Agent-engine research findings" --force`
+  - `gh label create codex-automation --color 5319E7 --description "Issue or PR created by Codex automation" --force`
 - Search open and closed issues plus open PRs first to avoid duplicates.
 - Reuse/extend existing issues when possible.
 - Open up to 3 high-signal non-duplicate issues per run only when confidence >= 0.8.
@@ -74,7 +75,7 @@ Issue policy:
   - broken or risky behavior
   - redundant/overcomplicated patterns
   - general improvement opportunities that materially improve reliability, clarity, velocity, or safety
-- Issue labels: `agent-engine-researcher`, `codex-automation`, and `self-improvement` when available.
+- Issue labels: `agent-engine-researcher`, `codex-automation`, and `self-improvement`.
 - Every created/updated issue must include:
   - Why This Change Makes Sense Now For Humans
   - Recommendation Metadata (rank, impact, effort, confidence)

--- a/agent-engine/automations/best-practice-researcher/best-practice-researcher.md
+++ b/agent-engine/automations/best-practice-researcher/best-practice-researcher.md
@@ -19,6 +19,10 @@ GitHub interaction policy: use `gh` CLI for all GitHub interactions in this run 
 
 Random-walk protocol:
 1. Read the last 8 entries in this automation memory and extract previous scope/domain/signal.
+   - Deterministic fallback when the automation memory file is missing or empty:
+     1) Retrieve fallback history from workflow-memory using `pnpm workflow-memory:retrieve --workflow "Periodic Scans" --tags best-practice-researcher --limit 8 --min-score 0`.
+     2) Use only fallback rows that include structured `scan` metadata (`walkMode`, `scope`, `domain`, `signal`) when deriving previous scope/domain/signal.
+     3) If fallback rows are used, append an initialization marker entry to `$CODEX_HOME/automations/best-practice-researcher/memory.md` before proceeding so the next run has deterministic local memory state.
 2. Choose a primary focus with weighted transitions, not pure random:
 - Scope transitions: macro -> (macro|meso), meso -> (macro|meso|micro), micro -> (micro|meso).
 - Walk mix target: about 25 percent macro, 45 percent meso, 30 percent micro over time.
@@ -51,6 +55,7 @@ Research protocol:
 Issue policy:
 - Ensure label availability before issue operations:
   - `gh label create best-practice-researcher --color 0052CC --description "Best-practice random-walk research findings" --force`
+  - `gh label create codex-automation --color 5319E7 --description "Issue or PR created by Codex automation" --force`
 - Search open and closed issues plus open PRs before creating anything.
 - Reuse/extend existing issues when possible.
 - Open up to 3 high-signal non-duplicate issues when confidence >= 0.8.
@@ -68,7 +73,7 @@ Issue policy:
   - Key paper idea(s) selected for this repo
   - Planned adaptation in this codebase (not generic advice)
   - Requirement that implementers append [`research/implemented-ideas.md`](../../../research/implemented-ideas.md) when shipped
-- Add labels `best-practice-researcher` and `codex-automation` when available.
+- Add labels `best-practice-researcher` and `codex-automation`.
 - Do not add `ready-for-dev` from this automation; `issue-evaluator` is the default label authority (humans may override when needed).
 - Do not add `self-improvement` from this automation.
 

--- a/agent-engine/automations/product-owner-reviewer/product-owner-reviewer.md
+++ b/agent-engine/automations/product-owner-reviewer/product-owner-reviewer.md
@@ -42,6 +42,7 @@ Review protocol:
 Issue policy:
 - Ensure label availability before issue operations:
   - `gh label create product-owner --color 1D76DB --description "Product owner UX and journey improvements" --force`
+  - `gh label create codex-automation --color 5319E7 --description "Issue or PR created by Codex automation" --force`
 - Search open and closed issues plus open PRs before creating anything.
 - Reuse/extend existing issues when possible.
 - Open up to 4 high-signal non-duplicate issues when confidence >= 0.75.
@@ -55,7 +56,7 @@ Issue policy:
   - Acceptance Criteria
   - Issue Evaluation Gate: implementation only after `issue-evaluator` (or explicit human override) applies the `ready-for-dev` label.
 - If external docs/research are cited, include a `References` section with direct clickable URLs and short relevance notes.
-- Add labels `product-owner` and `codex-automation` when available.
+- Add labels `product-owner` and `codex-automation`.
 - Do not add `ready-for-dev` from this automation; `issue-evaluator` is the default label authority (humans may override when needed).
 
 Memory logging contract (required every run, including no-op):

--- a/agent-engine/automations/product-vision-researcher/product-vision-researcher.md
+++ b/agent-engine/automations/product-vision-researcher/product-vision-researcher.md
@@ -47,6 +47,7 @@ Research protocol:
 Issue policy:
 - Ensure label availability before issue operations:
   - `gh label create product-vision --color 0E8A16 --description "Strategic product vision opportunities" --force`
+  - `gh label create codex-automation --color 5319E7 --description "Issue or PR created by Codex automation" --force`
 - Search open and closed issues plus open PRs before creating anything.
 - Reuse/extend existing issues when possible.
 - If a recommendation is materially the same topic as a prior issue (same user outcome + same core intervention), reuse that issue instead of creating a new one. Update the issue body/comment with the latest debate result (keep/amend/reject), new evidence, and revised priority.
@@ -68,7 +69,7 @@ Issue policy:
   - Key idea(s) selected for this repo
   - Planned adaptation in this codebase (not generic advice)
   - Requirement that implementers append [`research/implemented-ideas.md`](../../../research/implemented-ideas.md) when shipped
-- Add labels `product-vision` and `codex-automation` when available.
+- Add labels `product-vision` and `codex-automation`.
 - Do not add `ready-for-dev` from this automation; `issue-evaluator` is the default label authority (humans may override when needed).
 
 Memory logging contract (required every run, including no-op):

--- a/agent-engine/scripts/__tests__/automation-label-bootstrap.test.ts
+++ b/agent-engine/scripts/__tests__/automation-label-bootstrap.test.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CODEX_AUTOMATION_LABEL_BOOTSTRAP =
+  'gh label create codex-automation --color 5319E7 --description "Issue or PR created by Codex automation" --force';
+
+describe('automation label bootstrap guardrails', () => {
+  it('requires codex-automation bootstrap in research lane playbooks', async () => {
+    const playbookPaths = [
+      path.join(
+        process.cwd(),
+        'agent-engine',
+        'automations',
+        'best-practice-researcher',
+        'best-practice-researcher.md',
+      ),
+      path.join(
+        process.cwd(),
+        'agent-engine',
+        'automations',
+        'agent-engine-researcher',
+        'agent-engine-researcher.md',
+      ),
+      path.join(
+        process.cwd(),
+        'agent-engine',
+        'automations',
+        'product-vision-researcher',
+        'product-vision-researcher.md',
+      ),
+      path.join(
+        process.cwd(),
+        'agent-engine',
+        'automations',
+        'product-owner-reviewer',
+        'product-owner-reviewer.md',
+      ),
+    ];
+
+    const playbooks = await Promise.all(playbookPaths.map((filePath) => readFile(filePath, 'utf8')));
+
+    for (const playbook of playbooks) {
+      expect(playbook).toContain(CODEX_AUTOMATION_LABEL_BOOTSTRAP);
+      expect(playbook).not.toContain('codex-automation` when available');
+    }
+  });
+});

--- a/agent-engine/scripts/__tests__/best-practice-researcher-loop.test.ts
+++ b/agent-engine/scripts/__tests__/best-practice-researcher-loop.test.ts
@@ -14,4 +14,23 @@ describe('best-practice researcher loop wrapper', () => {
       "pnpm workflow-memory:retrieve --workflow 'Periodic Scans' --limit 1 --min-score 0 >/dev/null",
     );
   });
+
+  it('documents deterministic missing-memory fallback from Periodic Scans scan metadata', async () => {
+    const playbookPath = path.join(
+      process.cwd(),
+      'agent-engine',
+      'automations',
+      'best-practice-researcher',
+      'best-practice-researcher.md',
+    );
+    const playbook = await readFile(playbookPath, 'utf8');
+
+    expect(playbook).toContain(
+      'pnpm workflow-memory:retrieve --workflow "Periodic Scans" --tags best-practice-researcher --limit 8 --min-score 0',
+    );
+    expect(playbook).toContain('scan` metadata (`walkMode`, `scope`, `domain`, `signal`)');
+    expect(playbook).toContain(
+      'append an initialization marker entry to `$CODEX_HOME/automations/best-practice-researcher/memory.md`',
+    );
+  });
 });

--- a/packages/ai/src/errors.ts
+++ b/packages/ai/src/errors.ts
@@ -5,7 +5,6 @@ import type {
   PromptVersionBlockedError,
   PromptVersionNotFoundError,
 } from './chat/prompts/errors';
-import type { ToolFailureTag, ToolRemediation } from './tools/remediation';
 import type {
   ToolProviderError,
   ToolRateLimitError,
@@ -13,6 +12,7 @@ import type {
   ToolTimeoutError,
   ToolValidationError,
 } from './chat/tools/errors';
+import type { ToolFailureTag, ToolRemediation } from './tools/remediation';
 export {
   ToolProviderError,
   ToolRateLimitError,


### PR DESCRIPTION
Fixes #73
Fixes #74
Fixes #82

## Aggregated Issues
- Fixes #73 - deterministic fallback path for missing best-practice automation memory using Periodic Scans scan metadata plus initialization marker requirement.
- Fixes #74 - codex-automation label bootstrap standardized across research lanes with guardrail coverage.
- Fixes #82 - CI lint contract now executes scripts lint exactly once via pnpm lint.

## Workflow Routing
- #73: Feature Delivery + Self-Improvement (feature-delivery, test-surface-steward)
- #74: Self-Improvement (self-improvement, docs-knowledge-drift)
- #82: Feature Delivery (feature-delivery)

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build

## Research Log Update
- Not applicable (no Research Trace/paper-linked issues in this bundle).
