### PR TITLE
feat(tooling): restore spec generation and skill anchors

### DIFF
--- a/.agents/skills/codebase-nav/SKILL.md
+++ b/.agents/skills/codebase-nav/SKILL.md
@@ -32,14 +32,14 @@ Backend layer paths:
 
 Frontend paths:
 
-- Route tree + screens: `apps/web/src/router.tsx`, `apps/web/src/routeTree.gen.ts`
-- Features: `apps/web/src/features/`
+- Route tree + screens: `apps/web/src/router.tsx`, `apps/web/src/routeTree.gen.ts`, `apps/web/src/pages/`
+- Shared UI + utilities: `apps/web/src/components/`, `apps/web/src/lib/`
 - App shell/providers: `apps/web/src/main.tsx`
 
 Cross-cutting paths:
 
 - Query/API clients: `apps/web/src/clients/{api-client,auth-client}.ts`, `apps/web/src/query-client.ts`
-- SSE client flows: `apps/web/src/features` + `packages/api/src/contracts/events.ts`
+- SSE client flows: `apps/web/src/pages/`, `apps/web/src/lib/` + `packages/api/src/contracts/events.ts`
 - Invariants: `packages/api/src/server/__tests__/effect-handler.invariants.test.ts`, `packages/testing/src/__tests__/docs-invariants.test.ts`
 - Docs source of truth: `docs/master-spec.md`, `docs/spec/generated/`
 
@@ -52,7 +52,7 @@ Cross-cutting paths:
 3. Add run lifecycle behavior:
    - `packages/db/src/schemas/jobs.ts` -> `packages/queue/src/` -> `apps/worker/src/` -> SSE events in `packages/api/src/contracts/events.ts`
 4. Add frontend data flow:
-   - update route/view logic in `apps/web/src/router.tsx` -> supporting hooks/components in `apps/web/src/features/` -> tests
+   - update route/view logic in `apps/web/src/router.tsx` -> supporting modules in `apps/web/src/pages/`, `apps/web/src/components/`, or `apps/web/src/lib/` -> tests
 5. Fix invariant drift:
    - open invariant test file first, then follow the reported banned pattern path
 
@@ -71,7 +71,7 @@ Use fast path discovery before broad search:
 rg --files packages/ai/src/{chat,tts}
 rg --files packages/api/src/{contracts,server/router}
 rg --files packages/db/src/{schemas,__tests__}
-rg --files apps/web/src/{features,clients}
+rg --files apps/web/src/{pages,components,lib,clients}
 rg -n "createFileRoute\(|queryOptions\(|handleEffectWithProtocol\(" apps/web/src packages/api/src
 ```
 

--- a/.agents/skills/debug-fix/SKILL.md
+++ b/.agents/skills/debug-fix/SKILL.md
@@ -35,7 +35,7 @@ Extract the first concrete signal and follow it to source.
 - API contract mismatches:
   - compare `packages/api/src/contracts/*.ts` with router handler input/output use
 - Frontend query/mutation mismatches:
-  - verify query keys come from `queryOptions().queryKey` and hook wrappers under `apps/web/src/features/*/hooks/`
+  - verify query keys come from `queryOptions().queryKey` and wrappers under `apps/web/src/pages/` or shared logic in `apps/web/src/lib/`
 - Ownership/auth regressions:
   - verify ownership checks in use case before write/delete and ownership-scoped repo queries
 

--- a/.agents/skills/performance-cost-guard/SKILL.md
+++ b/.agents/skills/performance-cost-guard/SKILL.md
@@ -9,7 +9,7 @@ Use this skill for performance-sensitive changes, weekly quality scans, and rele
 
 ## Performance + Cost Surfaces
 
-- route-level frontend bundles and load behavior in `apps/web/src/router.tsx` and `apps/web/src/features/`
+- route-level frontend bundles and load behavior in `apps/web/src/router.tsx`, `apps/web/src/pages/`, and `apps/web/src/components/`
 - backend hot paths and job throughput in `packages/ai/src/{chat,tts}/use-cases/` and `apps/worker/src/`
 - CI/test runtime and build time via `package.json` scripts and affected package test folders
 - AI/provider usage patterns and token/call cost in `packages/ai/src/` and provider call sites

--- a/.agents/skills/periodic-scans/SKILL.md
+++ b/.agents/skills/periodic-scans/SKILL.md
@@ -29,8 +29,8 @@ Use this skill to run recurring repo scans and produce a prioritized backlog.
 - Cross-facet audit:
   - architecture boundary violations (`packages/api/src/server/router/` -> `packages/ai/src/{chat,tts}/use-cases/`)
   - authz gaps for mutating operations (`packages/api/src/server/router/`, `apps/server/src/`)
-  - query key/invalidation safety (`apps/web/src/features/*/hooks/`)
-  - frontend loading/error-state regressions (`apps/web/src/features/`, `apps/web/src/router.tsx`)
+  - query key/invalidation safety (`apps/web/src/query-client.ts`, `apps/web/src/clients/`, `apps/web/src/lib/`)
+  - frontend loading/error-state regressions (`apps/web/src/pages/`, `apps/web/src/components/`, `apps/web/src/router.tsx`)
   - performance regressions in route-level bundles and hot paths (`apps/web`, `apps/worker/src`, `packages/ai/src`)
   - security/dependency hygiene drift (`package.json`, `pnpm-lock.yaml`, `packages/*/package.json`)
   - agent-run/eval findings classified with `capability:*` and `failure:*` tags from [`agent-engine/workflow-memory/taxonomy.md`](../../../agent-engine/workflow-memory/taxonomy.md)

--- a/.agents/skills/pr-risk-review/SKILL.md
+++ b/.agents/skills/pr-risk-review/SKILL.md
@@ -29,9 +29,10 @@ Use this skill before merge for agent-authored or high-risk human-authored chang
 - sanitize user-editable structured fields:
   - prompt/config inputs in `packages/ai/src/chat/use-cases/` and `packages/api/src/contracts/runs.ts`
 - query key invalidation safety (no hardcoded keys):
-  - `apps/web/src/features/*/hooks/`
+  - `apps/web/src/pages/`
+  - `apps/web/src/lib/`
 - explicit streaming state + typed stream contracts:
-  - `apps/web/src/features/*/hooks/use-*-chat.ts`
+  - `apps/web/src/lib/chat-utils.ts`
   - `packages/api/src/contracts/chat.ts`
 - unsafe casts at production boundaries:
   - changed files (`as never`, `as unknown as`)

--- a/.agents/skills/release-incident-response/SKILL.md
+++ b/.agents/skills/release-incident-response/SKILL.md
@@ -22,7 +22,7 @@ Use this skill for release trains, hotfixes, and production incidents.
 1. Triage severity and user impact.
 2. Stabilize first (rollback, feature flag, hotfix).
 3. Identify root cause with evidence from changed files and failing tests in `packages/*/src/**/__tests__/` or `apps/web/src/**/__tests__/`.
-4. Patch and validate in the narrowest layer first (`packages/media/src/*/use-cases/`, `packages/api/src/server/router/`, or `apps/web/src/features/`).
+4. Patch and validate in the narrowest layer first (`packages/media/src/*/use-cases/`, `packages/api/src/server/router/`, `apps/web/src/pages/`, or `apps/web/src/lib/`).
 5. Run self-improvement loop to prevent recurrence.
 
 ## Rollback Triggers (Examples)

--- a/agent-engine/scripts/spec/generate-ui-surface.test.ts
+++ b/agent-engine/scripts/spec/generate-ui-surface.test.ts
@@ -1,0 +1,81 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockedPaths = vi.hoisted(() => ({
+  repoRoot: '',
+  generatedRoot: '',
+}));
+
+vi.mock('./utils', () => ({
+  repoRoot: mockedPaths.repoRoot,
+  generatedRoot: mockedPaths.generatedRoot,
+  writeUtf8: async (filePath: string, content: string) => {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      content.endsWith('\n') ? content : `${content}\n`,
+      'utf8',
+    );
+  },
+}));
+
+const tempDirs: string[] = [];
+
+const createTempRepo = async (): Promise<string> => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ui-surface-spec-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+};
+
+const writeFile = async (filePath: string, content: string): Promise<void> => {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf8');
+};
+
+describe('generateUiSurfaceArtifact', () => {
+  afterEach(async () => {
+    vi.resetModules();
+    while (tempDirs.length > 0) {
+      const tempDir = tempDirs.pop();
+      if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('handles missing optional module directories without failing', async () => {
+    const tempRepo = await createTempRepo();
+    mockedPaths.repoRoot = tempRepo;
+    mockedPaths.generatedRoot = path.join(tempRepo, 'docs/spec/generated');
+
+    await writeFile(
+      path.join(tempRepo, 'apps/web/src/routeTree.gen.ts'),
+      `export interface FileRoutesByFullPath {
+  '/': unknown;
+  '/jobs': unknown;
+}
+`,
+    );
+    await writeFile(
+      path.join(tempRepo, 'apps/web/src/pages/dashboard.tsx'),
+      'export const Dashboard = () => null;\n',
+    );
+
+    const { generateUiSurfaceArtifact } = await import('./generate-ui-surface');
+    const stats = await generateUiSurfaceArtifact();
+
+    expect(stats).toEqual({
+      routeCount: 2,
+      moduleCount: 1,
+    });
+
+    const generated = await fs.readFile(
+      path.join(mockedPaths.generatedRoot, 'ui-surface.md'),
+      'utf8',
+    );
+    expect(generated).toContain('- UI modules: 1');
+    expect(generated).toContain('`pages/dashboard`');
+    expect(generated).not.toContain('`components/');
+    expect(generated).not.toContain('## Feature Modules');
+  });
+});

--- a/agent-engine/scripts/spec/generate-ui-surface.ts
+++ b/agent-engine/scripts/spec/generate-ui-surface.ts
@@ -24,12 +24,68 @@ const extractRoutePaths = (source: string): string[] => {
   return [...routes].sort((a, b) => a.localeCompare(b));
 };
 
-const listFeatureModules = async (): Promise<readonly string[]> => {
-  const featuresDir = path.join(repoRoot, 'apps/web/src/features');
-  const entries = await fs.readdir(featuresDir, { withFileTypes: true });
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
+const MODULE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+const shouldIncludeModuleFile = (entryName: string): boolean => {
+  if (
+    entryName.endsWith('.test.ts') ||
+    entryName.endsWith('.test.tsx') ||
+    entryName.endsWith('.spec.ts') ||
+    entryName.endsWith('.spec.tsx') ||
+    entryName.endsWith('.d.ts')
+  ) {
+    return false;
+  }
+
+  return MODULE_EXTENSIONS.has(path.extname(entryName));
+};
+
+const collectModulesFromDirectory = async (
+  root: string,
+  label: string,
+  prefix = '',
+): Promise<readonly string[]> => {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const modules: string[] = [];
+  for (const entry of entries) {
+    const nextPrefix = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const fullPath = path.join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      const nested = await collectModulesFromDirectory(fullPath, label, nextPrefix);
+      modules.push(...nested);
+      continue;
+    }
+
+    if (!entry.isFile() || !shouldIncludeModuleFile(entry.name)) {
+      continue;
+    }
+
+    const modulePath = nextPrefix.replace(path.extname(nextPrefix), '');
+    modules.push(`${label}/${modulePath}`.replaceAll(path.sep, '/'));
+  }
+
+  return modules;
+};
+
+const listUiModules = async (): Promise<readonly string[]> => {
+  const webSrc = path.join(repoRoot, 'apps/web/src');
+  const modules = await Promise.all([
+    collectModulesFromDirectory(path.join(webSrc, 'pages'), 'pages'),
+    collectModulesFromDirectory(path.join(webSrc, 'components'), 'components'),
+    collectModulesFromDirectory(path.join(webSrc, 'lib'), 'lib'),
+  ]);
+
+  return modules
+    .flat()
     .sort((a, b) => a.localeCompare(b));
 };
 
@@ -42,14 +98,14 @@ const classifyAccess = (routePath: string): 'public' | 'protected' | 'shared' =>
 
 const formatUiSurfaceMarkdown = (
   routes: readonly string[],
-  features: readonly string[],
+  modules: readonly string[],
 ): string => {
   const lines: string[] = [];
 
   lines.push('# UI Surface (Generated)');
   lines.push('');
   lines.push(`- Routes: ${routes.length}`);
-  lines.push(`- Feature modules: ${features.length}`);
+  lines.push(`- UI modules: ${modules.length}`);
   lines.push('');
   lines.push('## Routes');
   lines.push('');
@@ -60,10 +116,10 @@ const formatUiSurfaceMarkdown = (
   }
 
   lines.push('');
-  lines.push('## Feature Modules');
+  lines.push('## UI Modules');
   lines.push('');
-  for (const feature of features) {
-    lines.push(`- \`${feature}\``);
+  for (const modulePath of modules) {
+    lines.push(`- \`${modulePath}\``);
   }
 
   return lines.join('\n');
@@ -71,22 +127,22 @@ const formatUiSurfaceMarkdown = (
 
 export type UiSurfaceStats = {
   readonly routeCount: number;
-  readonly featureModuleCount: number;
+  readonly moduleCount: number;
 };
 
 export const generateUiSurfaceArtifact = async (): Promise<UiSurfaceStats> => {
   const routeTreePath = path.join(repoRoot, 'apps/web/src/routeTree.gen.ts');
   const routeTreeSource = await fs.readFile(routeTreePath, 'utf8');
   const routes = extractRoutePaths(routeTreeSource);
-  const features = await listFeatureModules();
+  const modules = await listUiModules();
 
   await writeUtf8(
     path.join(generatedRoot, 'ui-surface.md'),
-    formatUiSurfaceMarkdown(routes, features),
+    formatUiSurfaceMarkdown(routes, modules),
   );
 
   return {
     routeCount: routes.length,
-    featureModuleCount: features.length,
+    moduleCount: modules.length,
   };
 };

--- a/agent-engine/scripts/spec/generate.ts
+++ b/agent-engine/scripts/spec/generate.ts
@@ -31,7 +31,7 @@ const createSnapshotMetadataMarkdown = (input: {
   tables: number;
   enums: number;
   routes: number;
-  features: number;
+  modules: number;
 }): string => {
   const lines: string[] = [];
   lines.push('# Snapshot Metadata (Generated)');
@@ -49,7 +49,7 @@ const createSnapshotMetadataMarkdown = (input: {
   lines.push(`- Database tables: ${input.tables}`);
   lines.push(`- Database enums: ${input.enums}`);
   lines.push(`- UI routes: ${input.routes}`);
-  lines.push(`- UI feature modules: ${input.features}`);
+  lines.push(`- UI modules: ${input.modules}`);
   lines.push('');
   lines.push('## Generated Files');
   lines.push('');
@@ -86,7 +86,7 @@ const run = async (): Promise<void> => {
       tables: dataModel.tableCount,
       enums: dataModel.enumCount,
       routes: ui.routeCount,
-      features: ui.featureModuleCount,
+      modules: ui.moduleCount,
     }),
   );
 

--- a/docs/master-spec.md
+++ b/docs/master-spec.md
@@ -66,20 +66,20 @@ pnpm spec:generate
 <!-- BEGIN GENERATED:snapshot-metadata -->
 # Snapshot Metadata (Generated)
 
-- Generated at: 2026-02-23T18:29:21.999Z
-- Git branch: main
-- Git commit: fc63c4c
+- Generated at: 2026-02-26T15:32:24.665Z
+- Git branch: codex/ready-for-dev-75-202602261025
+- Git commit: 3daab14
 
 ## Inventory
 
-- API endpoints: 4
+- API endpoints: 5
 - API tags: 3
 - Domains: 2
 - Use cases: 5
 - Database tables: 5
 - Database enums: 1
-- UI routes: 1
-- UI feature modules: 0
+- UI routes: 3
+- UI modules: 10
 
 ## Generated Files
 
@@ -95,12 +95,13 @@ pnpm spec:generate
 <!-- BEGIN GENERATED:api-surface -->
 # API Contract Surface (Generated)
 
-- Endpoints: 4
+- Endpoints: 5
 - Tags: chat, events, runs
 
 | Method | Path | Operation ID | Tags | Streaming | Summary |
 |---|---|---|---|---|---|
 | POST | /chat/general | chat.general | chat | yes |  |
+| POST | /chat/tools/weather/current | chat.weatherCurrent | chat | no |  |
 | GET | /events/ | events.subscribe | events | yes |  |
 | GET | /runs/ | runs.list | runs | no | List runs |
 | POST | /runs/ | runs.create | runs | no | Create run |
@@ -116,7 +117,7 @@ pnpm spec:generate
 
 | Domain | Use Cases | API Endpoints |
 |---|---|---|
-| chat | 1 | 1 |
+| chat | 1 | 2 |
 | tts | 4 | n/a |
 
 ## Use Cases by Domain
@@ -163,14 +164,27 @@ pnpm spec:generate
 <!-- BEGIN GENERATED:ui-surface -->
 # UI Surface (Generated)
 
-- Routes: 1
-- Feature modules: 0
+- Routes: 3
+- UI modules: 10
 
 ## Routes
 
 | Path | Access |
 |---|---|
 | / | public |
+| /chat | protected |
+| /jobs | protected |
 
-## Feature Modules
+## UI Modules
+
+- `components/app-shell`
+- `components/auth-gate`
+- `components/logo`
+- `components/weather-tool-panel`
+- `lib/chat-utils`
+- `lib/run-utils`
+- `lib/weather-tool`
+- `pages/chat`
+- `pages/dashboard`
+- `pages/jobs`
 <!-- END GENERATED:ui-surface -->

--- a/docs/spec/generated/openapi.json
+++ b/docs/spec/generated/openapi.json
@@ -290,6 +290,14 @@
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
                 "properties": {
+                  "idempotencyKey": {
+                    "description": "a string at most 128 character(s) long",
+                    "maxLength": 128,
+                    "minLength": 1,
+                    "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                    "title": "maxLength(128)",
+                    "type": "string"
+                  },
                   "prompt": {
                     "description": "a string at most 4000 character(s) long",
                     "maxLength": 4000,

--- a/docs/spec/generated/snapshot-metadata.md
+++ b/docs/spec/generated/snapshot-metadata.md
@@ -1,19 +1,19 @@
 # Snapshot Metadata (Generated)
 
-- Generated at: 2026-02-23T18:29:21.999Z
-- Git branch: main
-- Git commit: fc63c4c
+- Generated at: 2026-02-26T15:32:24.665Z
+- Git branch: codex/ready-for-dev-75-202602261025
+- Git commit: 3daab14
 
 ## Inventory
 
-- API endpoints: 4
+- API endpoints: 5
 - API tags: 3
 - Domains: 2
 - Use cases: 5
 - Database tables: 5
 - Database enums: 1
-- UI routes: 1
-- UI feature modules: 0
+- UI routes: 3
+- UI modules: 10
 
 ## Generated Files
 

--- a/docs/spec/generated/ui-surface.md
+++ b/docs/spec/generated/ui-surface.md
@@ -1,12 +1,25 @@
 # UI Surface (Generated)
 
-- Routes: 1
-- Feature modules: 0
+- Routes: 3
+- UI modules: 10
 
 ## Routes
 
 | Path | Access |
 |---|---|
 | / | public |
+| /chat | protected |
+| /jobs | protected |
 
-## Feature Modules
+## UI Modules
+
+- `components/app-shell`
+- `components/auth-gate`
+- `components/logo`
+- `components/weather-tool-panel`
+- `lib/chat-utils`
+- `lib/run-utils`
+- `lib/weather-tool`
+- `pages/chat`
+- `pages/dashboard`
+- `pages/jobs`


### PR DESCRIPTION
Fixes #75
Fixes #76

## Summary
- update `agent-engine/scripts/spec/generate-ui-surface.ts` to discover UI modules from `apps/web/src/pages`, `apps/web/src/components`, and `apps/web/src/lib`
- make module discovery resilient to missing optional directories (no hard failure on absent paths)
- add regression coverage in `agent-engine/scripts/spec/generate-ui-surface.test.ts` for missing-directory behavior
- regenerate spec artifacts (`docs/master-spec.md`, `docs/spec/generated/*`) with the updated UI module inventory
- replace stale `apps/web/src/features/*` anchors in canonical `.agents/skills/*` and sync mirrors

## Aggregated Issues
- Fixes #75 - restore `pnpm spec:generate` against current web project structure and add missing-directory regression test
- Fixes #76 - update stale skill path anchors to current web paths and enforce mirror parity/strict skill checks

## Workflow Routing
- #75 -> `Feature Delivery` workflow using `$feature-delivery` + `$debug-fix` (focused reproduce/fix/validate for broken spec generation)
- #76 -> `Feature Delivery` workflow using `$feature-delivery` + `$codebase-nav` (canonical skill path updates + mirror sync)

## Validation
- `pnpm skills:check:strict`
- `pnpm spec:generate`
- `pnpm test:scripts -- --run agent-engine/scripts/spec/generate-ui-surface.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- No research-trace/paper-linked issue in this bundle; `research/implemented-ideas.md` not updated.
