### PR TITLE
fix(server): enforce explicit credentialed CORS allowlist

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -28,6 +28,11 @@ PUBLIC_SERVER_API_PATH=/api
 
 # Frontend URL, used to configure trusted origin (cors)
 PUBLIC_WEB_URL=http://localhost:8085
+# Optional extra allowed origins for credentialed CORS (comma-separated).
+# For local dev with multiple frontends, prefer explicit localhost entries:
+# CORS_ORIGINS=http://localhost:4173,http://127.0.0.1:8085
+# Wildcard (*) is intentionally rejected for credentialed routes.
+# CORS_ORIGINS=
 
 # AI Configuration
 # Use mock AI services for LLM and TTS (set to false to use real AI)

--- a/apps/server/src/__tests__/cors-config.test.ts
+++ b/apps/server/src/__tests__/cors-config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildCredentialedCorsOriginConfig } from '../cors-config';
+
+describe('buildCredentialedCorsOriginConfig', () => {
+  it('rejects wildcard CORS_ORIGINS when credentials are enabled', () => {
+    expect(() =>
+      buildCredentialedCorsOriginConfig({
+        publicWebUrl: 'http://localhost:8085',
+        corsOrigins: '*',
+      }),
+    ).toThrow('CORS_ORIGINS=* is not allowed for credentialed CORS');
+  });
+
+  it('includes PUBLIC_WEB_URL and normalizes extra origins', () => {
+    expect(
+      buildCredentialedCorsOriginConfig({
+        publicWebUrl: 'http://localhost:8085/path',
+        corsOrigins: 'https://app.example.com/home, http://localhost:4173',
+      }),
+    ).toEqual([
+      'http://localhost:8085',
+      'https://app.example.com',
+      'http://localhost:4173',
+    ]);
+  });
+
+  it('deduplicates and trims values', () => {
+    expect(
+      buildCredentialedCorsOriginConfig({
+        publicWebUrl: 'http://localhost:8085',
+        corsOrigins:
+          ' http://localhost:8085 , http://localhost:8085 , http://localhost:4173 ',
+      }),
+    ).toEqual(['http://localhost:8085', 'http://localhost:4173']);
+  });
+});

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -1,4 +1,5 @@
 import type { StorageConfig } from '@repo/api/server';
+import { buildCredentialedCorsOriginConfig } from './cors-config';
 import { env } from './env';
 
 export const buildStorageConfig = (): StorageConfig => {
@@ -43,20 +44,10 @@ export const buildStorageConfig = (): StorageConfig => {
 };
 
 /**
- * CORS origins. Set CORS_ORIGINS=* for fully permissive mode (reflects
- * any requesting origin). Otherwise falls back to PUBLIC_WEB_URL.
+ * CORS allowlist for credentialed auth/API routes.
+ * Use explicit origins only; wildcard mode is rejected at startup.
  */
-export const corsOriginConfig: string[] | '*' = (() => {
-  if (env.CORS_ORIGINS === '*') return '*';
-  const origins = [env.PUBLIC_WEB_URL];
-  if (env.CORS_ORIGINS) {
-    origins.push(...env.CORS_ORIGINS.split(',').map((s) => s.trim()));
-  }
-  return origins.map((url) => {
-    try {
-      return new URL(url).origin;
-    } catch {
-      return url;
-    }
-  });
-})();
+export const corsOriginConfig = buildCredentialedCorsOriginConfig({
+  publicWebUrl: env.PUBLIC_WEB_URL,
+  corsOrigins: env.CORS_ORIGINS,
+});

--- a/apps/server/src/cors-config.ts
+++ b/apps/server/src/cors-config.ts
@@ -1,0 +1,27 @@
+const normalizeOrigin = (url: string): string => {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+};
+
+export const buildCredentialedCorsOriginConfig = (input: {
+  publicWebUrl: string;
+  corsOrigins?: string;
+}): string[] => {
+  if (input.corsOrigins?.trim() === '*') {
+    throw new Error(
+      'CORS_ORIGINS=* is not allowed for credentialed CORS. Set explicit origins instead.',
+    );
+  }
+
+  const origins = [input.publicWebUrl];
+  if (input.corsOrigins) {
+    origins.push(...input.corsOrigins.split(',').map((s) => s.trim()));
+  }
+
+  return [...new Set(origins.filter((origin) => origin.length > 0))].map(
+    normalizeOrigin,
+  );
+};

--- a/apps/server/src/routes/api.ts
+++ b/apps/server/src/routes/api.ts
@@ -10,7 +10,7 @@ const apiRateLimit = createApiRateLimit({ redisUrl: env.SERVER_REDIS_URL });
 export const apiRoute = new Hono<{ Variables: { requestId: string } }>()
   .use(
     cors({
-      origin: corsOriginConfig === '*' ? (origin) => origin : corsOriginConfig,
+      origin: corsOriginConfig,
       credentials: true,
     }),
   )

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -10,7 +10,7 @@ const authRateLimit = createAuthRateLimit({ redisUrl: env.SERVER_REDIS_URL });
 export const authRoute = new Hono()
   .use(
     cors({
-      origin: corsOriginConfig === '*' ? (origin) => origin : corsOriginConfig,
+      origin: corsOriginConfig,
       credentials: true,
       allowHeaders: ['Content-Type', 'Authorization'],
       allowMethods: ['POST', 'GET', 'OPTIONS'],

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,6 +17,13 @@ pnpm db:push
 pnpm dev
 ```
 
+Local CORS note (credentialed auth/API routes): avoid wildcard origins.
+Use explicit local allowlist values instead, for example:
+
+```bash
+CORS_ORIGINS=http://localhost:4173,http://127.0.0.1:8085
+```
+
 ## Quality Checks
 
 ```bash

--- a/research/implemented-ideas.md
+++ b/research/implemented-ideas.md
@@ -15,7 +15,7 @@ Use this file to capture shipped ideas discovered through automation/research la
 - Date: 2026-02-26
 - Source lane/workflow: ready-for-dev-executor / Feature Delivery
 - Issue: https://github.com/brandonbryant12/agent-engine-template/issues/88
-- PR: pending (update before merge)
+- PR: https://github.com/brandonbryant12/agent-engine-template/pull/96
 - Paper/reference links: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSNotSupportingCredentials, https://cheatsheetseries.owasp.org/cheatsheets/Cross_Origin_Resource_Sharing_Cheat_Sheet.html
 - Idea(s) adopted: reject wildcard origin mode for credentialed CORS at runtime startup and require explicit origin allowlists.
 - Implemented in: `apps/server/src/cors-config.ts`, `apps/server/src/config.ts`, `apps/server/src/routes/api.ts`, `apps/server/src/routes/auth.ts`, `apps/server/src/__tests__/cors-config.test.ts`, `apps/server/.env.example`, and `docs/setup.md`.

--- a/research/implemented-ideas.md
+++ b/research/implemented-ideas.md
@@ -12,6 +12,15 @@ Use this file to capture shipped ideas discovered through automation/research la
 
 ## Entries
 
+- Date: 2026-02-26
+- Source lane/workflow: ready-for-dev-executor / Feature Delivery
+- Issue: https://github.com/brandonbryant12/agent-engine-template/issues/88
+- PR: pending (update before merge)
+- Paper/reference links: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSNotSupportingCredentials, https://cheatsheetseries.owasp.org/cheatsheets/Cross_Origin_Resource_Sharing_Cheat_Sheet.html
+- Idea(s) adopted: reject wildcard origin mode for credentialed CORS at runtime startup and require explicit origin allowlists.
+- Implemented in: `apps/server/src/cors-config.ts`, `apps/server/src/config.ts`, `apps/server/src/routes/api.ts`, `apps/server/src/routes/auth.ts`, `apps/server/src/__tests__/cors-config.test.ts`, `apps/server/.env.example`, and `docs/setup.md`.
+- Follow-up: if route-level CORS policies diverge later, keep credentialed-route defaults strict and test each policy surface independently.
+
 - Date: 2026-02-25
 - Source lane/workflow: ready-for-dev-executor / Feature Delivery + Architecture + ADR Guard
 - Issue: https://github.com/brandonbryant12/agent-engine-template/issues/58


### PR DESCRIPTION
Fixes #88

## Summary
- reject `CORS_ORIGINS=*` for credentialed auth/API CORS at runtime startup
- remove wildcard-origin reflection code paths from server auth/api routes
- add deterministic tests for wildcard rejection and origin normalization/deduplication
- document safe local-dev explicit allowlist pattern in server env example and setup docs

## Aggregated Issues
- Fixes #88 (fully resolved)

## Workflow Routing
- #88 -> Feature Delivery (primary) using `feature-delivery` + companion `security-dependency-hygiene` checks because this is credentialed CORS hardening in auth/API ingress.

## Research Log Update
- Added `research/implemented-ideas.md` entry for issue #88 with source references and implemented surfaces.

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build
