### PR TITLE
fix(server): harden rate-limit identity extraction

### DIFF
--- a/apps/server/src/__tests__/rate-limit.test.ts
+++ b/apps/server/src/__tests__/rate-limit.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { rateLimiter } from '../middleware/rate-limit';
+import { rateLimiter, resolveRateLimitIdentity } from '../middleware/rate-limit';
 
 describe('rateLimiter middleware', () => {
   let app: Hono;
@@ -193,5 +193,62 @@ describe('rateLimiter middleware', () => {
 
     expect(res.status).toBe(429);
     expect(consume).toHaveBeenCalledOnce();
+  });
+
+  it('ignores spoofed forwarded headers when remote address is untrusted', () => {
+    const identity = resolveRateLimitIdentity({
+      remoteAddress: '198.51.100.9',
+      forwardedHeader: '203.0.113.1, 203.0.113.2',
+      realIpHeader: '203.0.113.3',
+      config: {
+        trustProxy: true,
+        trustedHops: 1,
+        trustedProxyMatchers: ['loopback', 'private'],
+      },
+    });
+
+    expect(identity).toBe('198.51.100.9');
+  });
+
+  it('uses trusted forwarded chain when request comes from trusted proxy', () => {
+    const identity = resolveRateLimitIdentity({
+      remoteAddress: '10.0.0.10',
+      forwardedHeader: '203.0.113.50, 198.51.100.7',
+      config: {
+        trustProxy: true,
+        trustedHops: 1,
+        trustedProxyMatchers: ['private'],
+      },
+    });
+
+    expect(identity).toBe('198.51.100.7');
+  });
+
+  it('normalizes IPv6-mapped IPv4 inputs', () => {
+    const identity = resolveRateLimitIdentity({
+      remoteAddress: '::ffff:10.0.0.10',
+      forwardedHeader: '::ffff:203.0.113.9',
+      config: {
+        trustProxy: true,
+        trustedHops: 1,
+        trustedProxyMatchers: ['private'],
+      },
+    });
+
+    expect(identity).toBe('203.0.113.9');
+  });
+
+  it('falls back to unknown when headers are malformed and remote is missing', () => {
+    const identity = resolveRateLimitIdentity({
+      forwardedHeader: 'not-an-ip',
+      realIpHeader: 'also-not-an-ip',
+      config: {
+        trustProxy: true,
+        trustedHops: 1,
+        trustedProxyMatchers: ['private'],
+      },
+    });
+
+    expect(identity).toBe('unknown');
   });
 });

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net';
+import { getConnInfo } from '@hono/node-server/conninfo';
 import { createClient } from 'redis';
 import type { Context, MiddlewareHandler } from 'hono';
 
@@ -37,8 +39,24 @@ interface RateLimitStore {
   shutdown?: () => Promise<void>;
 }
 
+interface TrustedProxyConfig {
+  trustProxy: boolean;
+  trustedHops: number;
+  trustedProxyMatchers: readonly string[];
+}
+
+interface RateLimitIdentityInput {
+  remoteAddress?: string;
+  forwardedHeader?: string;
+  realIpHeader?: string;
+  config?: TrustedProxyConfig;
+}
+
 const DEFAULT_KEY_PREFIX = 'cs:rate-limit';
 const LOG_PREFIX = '[RateLimit]';
+const TRUST_PROXY_ENV = 'RATE_LIMIT_TRUST_PROXY';
+const TRUSTED_HOPS_ENV = 'RATE_LIMIT_TRUSTED_HOPS';
+const TRUSTED_PROXIES_ENV = 'RATE_LIMIT_TRUSTED_PROXIES';
 
 const REDIS_WINDOW_SCRIPT = `
 local current = redis.call('INCR', KEYS[1])
@@ -64,6 +82,162 @@ function toNumber(value: unknown, fallback: number): number {
     if (Number.isFinite(parsed)) return parsed;
   }
   return fallback;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!value) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function parseTrustedHops(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+function normalizeIp(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const withoutZone = trimmed.split('%')[0] ?? trimmed;
+  const unwrapped =
+    withoutZone.startsWith('[') && withoutZone.endsWith(']')
+      ? withoutZone.slice(1, -1)
+      : withoutZone;
+
+  if (unwrapped.toLowerCase().startsWith('::ffff:')) {
+    const mapped = unwrapped.slice('::ffff:'.length);
+    if (isIP(mapped) === 4) {
+      return mapped;
+    }
+  }
+
+  if (isIP(unwrapped)) {
+    return unwrapped;
+  }
+
+  return undefined;
+}
+
+function isLoopbackAddress(address: string): boolean {
+  return address === '127.0.0.1' || address === '::1';
+}
+
+function isPrivateAddress(address: string): boolean {
+  if (isIP(address) === 4) {
+    return (
+      address.startsWith('10.') ||
+      address.startsWith('192.168.') ||
+      /^172\.(1[6-9]|2\d|3[0-1])\./.test(address)
+    );
+  }
+
+  if (isIP(address) === 6) {
+    const lowered = address.toLowerCase();
+    return lowered.startsWith('fc') || lowered.startsWith('fd');
+  }
+
+  return false;
+}
+
+function isTrustedProxyAddress(
+  address: string,
+  trustedProxyMatchers: readonly string[],
+): boolean {
+  for (const matcher of trustedProxyMatchers) {
+    if (matcher === '*') return true;
+    if (matcher === 'loopback' && isLoopbackAddress(address)) return true;
+    if (matcher === 'private' && isPrivateAddress(address)) return true;
+    if (matcher === address) return true;
+  }
+
+  return false;
+}
+
+function parseForwardedHeader(header: string | undefined): string[] {
+  if (!header) return [];
+
+  const ips = header
+    .split(',')
+    .map((candidate) => normalizeIp(candidate))
+    .filter((candidate): candidate is string => Boolean(candidate));
+
+  return ips;
+}
+
+function getServerRemoteAddress(c: Context): string | undefined {
+  try {
+    return normalizeIp(getConnInfo(c).remote.address);
+  } catch {
+    return undefined;
+  }
+}
+
+function buildTrustedProxyConfig(): TrustedProxyConfig {
+  const trustProxy = parseBoolean(process.env[TRUST_PROXY_ENV], true);
+  const trustedHops = parseTrustedHops(process.env[TRUSTED_HOPS_ENV], 1);
+  const trustedProxyMatchers = (
+    process.env[TRUSTED_PROXIES_ENV] ?? 'loopback,private'
+  )
+    .split(',')
+    .map((matcher) => matcher.trim().toLowerCase())
+    .filter(Boolean);
+
+  return {
+    trustProxy,
+    trustedHops,
+    trustedProxyMatchers,
+  };
+}
+
+const trustedProxyConfig = buildTrustedProxyConfig();
+
+function selectClientIpFromForwardedChain(
+  forwardedIps: readonly string[],
+  trustedHops: number,
+): string | undefined {
+  if (forwardedIps.length === 0) return undefined;
+  const index = forwardedIps.length - trustedHops;
+  if (index < 0) return undefined;
+  return forwardedIps[index];
+}
+
+export function resolveRateLimitIdentity(input: RateLimitIdentityInput): string {
+  const config = input.config ?? trustedProxyConfig;
+  const remoteAddress = normalizeIp(input.remoteAddress);
+
+  if (!config.trustProxy) {
+    return remoteAddress ?? 'unknown';
+  }
+
+  const forwardedIps = parseForwardedHeader(input.forwardedHeader);
+  const realIp = normalizeIp(input.realIpHeader);
+
+  // In test/local harnesses, socket-derived remote address may be unavailable.
+  if (!remoteAddress) {
+    return realIp ?? forwardedIps[0] ?? 'unknown';
+  }
+
+  if (!isTrustedProxyAddress(remoteAddress, config.trustedProxyMatchers)) {
+    return remoteAddress;
+  }
+
+  const forwardedCandidate = selectClientIpFromForwardedChain(
+    forwardedIps,
+    config.trustedHops,
+  );
+
+  if (forwardedCandidate) {
+    return forwardedCandidate;
+  }
+
+  return realIp ?? remoteAddress;
 }
 
 function createInMemoryStore(cleanupIntervalMs: number): RateLimitStore {
@@ -234,15 +408,11 @@ export const rateLimiter = (opts: RateLimitOptions): MiddlewareHandler => {
 };
 
 function defaultKeyGenerator(c: Context): string {
-  const forwarded = c.req.header('x-forwarded-for');
-  if (forwarded) {
-    return forwarded.split(',')[0]!.trim();
-  }
-  const realIp = c.req.header('x-real-ip');
-  if (realIp) {
-    return realIp;
-  }
-  return 'unknown';
+  return resolveRateLimitIdentity({
+    remoteAddress: getServerRemoteAddress(c),
+    forwardedHeader: c.req.header('x-forwarded-for'),
+    realIpHeader: c.req.header('x-real-ip'),
+  });
 }
 
 export async function shutdownRateLimiters(): Promise<void> {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -22,3 +22,4 @@
 - Persistence in `packages/db` and `packages/queue`
 - Auth in `packages/auth`
 - AI tool authoring standard in `docs/architecture/ai-sdk-tooling-standard.md`
+- Rate-limit identity derivation in `docs/architecture/rate-limit-identity.md`

--- a/docs/architecture/rate-limit-identity.md
+++ b/docs/architecture/rate-limit-identity.md
@@ -1,0 +1,48 @@
+# Rate-Limit Identity and Trusted Proxies
+
+Rate limiting now derives identity from a server-verified socket address first,
+then only considers forwarded headers when the immediate sender is trusted.
+
+## Resolution Order
+
+1. Read remote socket address via `@hono/node-server/conninfo`.
+2. If proxy trust is disabled, use the remote socket address only.
+3. If proxy trust is enabled and remote sender is trusted:
+   - Parse `x-forwarded-for` and select the client hop based on trusted proxy
+     hop count.
+   - Fall back to `x-real-ip` when forwarded chain is unavailable.
+4. If no valid signal exists, use `unknown`.
+
+Malformed or non-IP forwarded headers are ignored.
+
+## Environment Controls
+
+- `RATE_LIMIT_TRUST_PROXY` (default: `true`)
+  Enables trusted-proxy header processing.
+- `RATE_LIMIT_TRUSTED_HOPS` (default: `1`)
+  Number of trusted proxy hops between app and client identity.
+- `RATE_LIMIT_TRUSTED_PROXIES` (default: `loopback,private`)
+  CSV allowlist for immediate sender trust:
+  - `loopback` for `127.0.0.1` / `::1`
+  - `private` for RFC1918/ULA ranges
+  - exact IP values
+  - `*` to trust all senders (not recommended)
+
+## Deployment Assumptions
+
+- Single proxy:
+  Keep `RATE_LIMIT_TRUSTED_HOPS=1` and include ingress proxy source addresses
+  in `RATE_LIMIT_TRUSTED_PROXIES`.
+- Chained proxies:
+  Set `RATE_LIMIT_TRUSTED_HOPS` to the number of trusted hops nearest the app,
+  and ensure each trusted hop is represented by the trusted sender allowlist.
+- Local development:
+  Defaults (`loopback,private`) support local reverse proxies and local direct
+  requests without extra configuration.
+
+## Security Outcome
+
+- Direct internet clients cannot bypass limits by spoofing `x-forwarded-for`
+  because their untrusted remote address is used as the identity key.
+- Trusted ingress still preserves per-client rate limiting by forwarding a
+  validated proxy chain.


### PR DESCRIPTION
Fixes #89

## Summary
- harden rate-limit identity extraction to start from server-verified remote socket address
- trust forwarded headers only when the immediate sender is in a trusted proxy allowlist
- add explicit architecture documentation for single proxy, chained proxy, and local dev deployment assumptions
- add spoofing and normalization tests for trusted/untrusted proxy paths

## Aggregated Issues
- Fixes #89 - trusted-proxy-aware rate-limit identity extraction and docs/tests

## Workflow Routing
- #89 -> Feature Delivery (`feature-delivery`, `intake-triage`) for middleware+tests+docs implementation
- #89 -> Feature Delivery companion guardrails (`security-dependency-hygiene`) for spoof-resistance and trust-boundary checks

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test:invariants
- pnpm test
- pnpm build
