### PR TITLE
feat(ci): add affected-mode PR validation path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,72 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      CI_MODE: full
+      CI_MODE_REASON: non-pr-event
+      TURBO_SCM_BASE: ""
+      TURBO_SCM_HEAD: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR affected mode
+        id: affected
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+
+          if [[ -z "${BASE_SHA}" || -z "${HEAD_SHA}" ]]; then
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "reason=missing-pr-sha" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags origin "${BASE_REF}:${BASE_REF}" "${HEAD_REF}:${HEAD_REF}" || true
+
+          if git cat-file -e "${BASE_SHA}^{commit}" && git cat-file -e "${HEAD_SHA}^{commit}"; then
+            echo "mode=affected" >> "$GITHUB_OUTPUT"
+            echo "reason=resolved-pr-shas" >> "$GITHUB_OUTPUT"
+            echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "reason=unresolved-pr-shas" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set CI mode env
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ steps.affected.outputs.mode }}" == "affected" ]]; then
+            echo "CI_MODE=affected" >> "$GITHUB_ENV"
+            echo "CI_MODE_REASON=${{ steps.affected.outputs.reason }}" >> "$GITHUB_ENV"
+            echo "TURBO_SCM_BASE=${{ steps.affected.outputs.base_sha }}" >> "$GITHUB_ENV"
+            echo "TURBO_SCM_HEAD=${{ steps.affected.outputs.head_sha }}" >> "$GITHUB_ENV"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "CI_MODE=full" >> "$GITHUB_ENV"
+            echo "CI_MODE_REASON=${{ steps.affected.outputs.reason || 'base-unresolved-fallback' }}" >> "$GITHUB_ENV"
+            echo "TURBO_SCM_BASE=" >> "$GITHUB_ENV"
+            echo "TURBO_SCM_HEAD=" >> "$GITHUB_ENV"
+          fi
+
+      - name: CI mode summary
+        run: |
+          echo "CI mode: ${CI_MODE}"
+          echo "Reason: ${CI_MODE_REASON}"
+          if [[ "${CI_MODE}" == "affected" ]]; then
+            echo "TURBO_SCM_BASE=${TURBO_SCM_BASE}"
+            echo "TURBO_SCM_HEAD=${TURBO_SCM_HEAD}"
+          fi
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -38,23 +101,44 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
+      - name: Typecheck (Affected)
+        if: env.CI_MODE == 'affected'
+        run: pnpm turbo run typecheck --affected
+
+      - name: Typecheck (Full)
+        if: env.CI_MODE != 'affected'
         run: pnpm typecheck
 
-      - name: Lint
-        # Root lint script already runs `pnpm scripts:lint` first, then package lint tasks.
-        # Keep this as the single scripts-lint execution path in CI.
+      - name: Lint Scripts
         env:
           GH_TOKEN: ${{ github.token }}
           BEST_PRACTICE_TRACEABILITY_ENFORCE: "1"
           BEST_PRACTICE_TRACEABILITY_LOOKBACK_DAYS: "1"
-        run: pnpm lint
+        run: pnpm scripts:lint
 
-      - name: Test
+      - name: Lint (Affected)
+        if: env.CI_MODE == 'affected'
+        run: pnpm turbo run lint --affected -- --cache --cache-location .cache/.eslintcache --max-warnings=0
+
+      - name: Lint (Full)
+        if: env.CI_MODE != 'affected'
+        run: pnpm turbo run lint --continue -- --cache --cache-location .cache/.eslintcache --max-warnings=0
+
+      - name: Test (Affected)
+        if: env.CI_MODE == 'affected'
+        run: pnpm turbo run test --affected
+
+      - name: Test (Full)
+        if: env.CI_MODE != 'affected'
         run: pnpm test
 
       - name: Test Invariants
         run: pnpm test:invariants
 
-      - name: Build
+      - name: Build (Affected)
+        if: env.CI_MODE == 'affected'
+        run: pnpm turbo run build --affected
+
+      - name: Build (Full)
+        if: env.CI_MODE != 'affected'
         run: pnpm build

--- a/README.md
+++ b/README.md
@@ -101,10 +101,23 @@ The canonical repository CI contract lives at
 `.github/workflows/ci.yml`.
 
 For every PR to `main`, CI pins Node (`22.10.0`), installs with
-`pnpm install --frozen-lockfile`, and runs:
+`pnpm install --frozen-lockfile`, then:
+
+- resolves PR base/head SHAs with full checkout history (`fetch-depth: 0`)
+- runs Turbo affected-mode for Turbo-backed tasks when base/head resolve:
+  - `pnpm turbo run typecheck --affected`
+  - `pnpm turbo run lint --affected`
+  - `pnpm turbo run test --affected`
+  - `pnpm turbo run build --affected`
+- falls back to full-mode commands when base/head cannot be resolved
+- always runs non-Turbo repository guards:
+  - `pnpm scripts:lint`
+- `pnpm test:invariants`
+
+For `push` to `main`, CI always runs full validation:
 
 - `pnpm typecheck`
-- `pnpm lint`
+- `pnpm turbo run lint --continue -- --cache --cache-location .cache/.eslintcache --max-warnings=0`
 - `pnpm test`
 - `pnpm test:invariants`
 - `pnpm build`

--- a/research/implemented-ideas.md
+++ b/research/implemented-ideas.md
@@ -14,6 +14,15 @@ Use this file to capture shipped ideas discovered through automation/research la
 
 - Date: 2026-02-26
 - Source lane/workflow: ready-for-dev-executor / Feature Delivery
+- Issue: https://github.com/brandonbryant12/agent-engine-template/issues/84
+- PR: https://github.com/brandonbryant12/agent-engine-template/pull/102
+- Paper/reference links: https://turborepo.com/docs/crafting-your-repository/constructing-ci, https://github.com/actions/checkout
+- Idea(s) adopted: execute Turbo-backed CI gates in affected mode for pull requests with explicit base/head SHA resolution and deterministic fallback to full validation.
+- Implemented in: `.github/workflows/ci.yml` and `README.md`.
+- Follow-up: if affected selection ever misses required surfaces, keep fallback full-mode path available and revisit base/head resolution diagnostics.
+
+- Date: 2026-02-26
+- Source lane/workflow: ready-for-dev-executor / Feature Delivery
 - Issue: https://github.com/brandonbryant12/agent-engine-template/issues/88
 - PR: https://github.com/brandonbryant12/agent-engine-template/pull/96
 - Paper/reference links: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSNotSupportingCredentials, https://cheatsheetseries.owasp.org/cheatsheets/Cross_Origin_Resource_Sharing_Cheat_Sheet.html


### PR DESCRIPTION
Fixes #84

## Summary
- add PR-mode affected CI execution for Turbo-backed tasks in `.github/workflows/ci.yml`
- keep push-to-main full validation gates unchanged in intent
- preserve non-Turbo guards (`pnpm scripts:lint`, `pnpm test:invariants`) in both modes
- add explicit base/head resolution and full-mode fallback when PR SHAs cannot be resolved
- document affected-mode boundaries and fallback behavior in `README.md`

## Aggregated Issues
- Fixes #84 (fully resolved)

## Workflow Routing
- #84 -> Feature Delivery (primary); skills: feature-delivery, intake-triage, codebase-nav

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:invariants`
- `pnpm test`
- `pnpm build`

## Research Log Update
- Issue includes external references; `research/implemented-ideas.md` will be updated in this PR with issue/PR/reference/adoption details.
